### PR TITLE
Compile released bundles for Java 17 instead of 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ The project uses a Gradle + BND workspace:
 ./gradlew clean       # Clean build artifacts
 ```
 
-Requires Java 21.
+Building requires Java 21. The released bundles are compiled for Java 17
+(`osgi.ee=JavaSE-17`), so consuming them — including running the code
+generator — works on JDK 17 and newer.
 
 ## Gecko EMF Compatibility
 

--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -1,5 +1,8 @@
-javac.source: 21
-javac.target: 21
+# Lowest feasible compile level so downstream JDK 17 toolchains can consume
+# the released bundles (see issue #37); the build JDK itself stays at 21.
+# The code uses records and instanceof patterns (Java 16), so 17 is the floor.
+javac.source: 17
+javac.target: 17
 
 # Copyright (c) 2012 - 2025 Data In Motion and others.
 # All rights reserved. 

--- a/org.eclipse.fennec.emf.osgi.codegen.test/bnd.bnd
+++ b/org.eclipse.fennec.emf.osgi.codegen.test/bnd.bnd
@@ -1,6 +1,3 @@
-javac.source: 17
-javac.target: 17
-
 -testpath: \
 	slf4j.api;version=latest,\
 	org.osgi.service.repository;version=latest,\

--- a/org.eclipse.fennec.emf.osgi.codegen/bnd.bnd
+++ b/org.eclipse.fennec.emf.osgi.codegen/bnd.bnd
@@ -1,8 +1,5 @@
 src=${^src}
 
-javac.source: 17
-javac.target: 17
-
 -buildpath: \
 	org.osgi.annotation.bundle;version=latest,\
 	org.osgi.annotation.versioning;version=latest,\


### PR DESCRIPTION
Fixes #37.

## What

- `cnf/build.bnd`: workspace-wide `javac.source`/`javac.target` 21 → 17. The build JDK stays at 21 (CI unchanged).
- Removes the now-redundant per-project 17 overrides in `org.eclipse.fennec.emf.osgi.codegen{,.test}` so the compile level has a single source of truth.
- README: clarifies that Java 21 is only needed for *building*; consuming the released bundles and running the code generator works on JDK 17+.

## Why 17

The code uses records and `instanceof` patterns (Java 16 features, e.g. in `org.eclipse.fennec.emf.osgi.api`), so 17 is the lowest feasible LTS release — matching what the issue proposed and what downstream JDK 17 toolchains (e.g. Eclipse sensiNact) need.

## Verification

- `./gradlew build` green (unit tests + baselining).
- `bnd ees` on the built jars: `api`, `component`, `component.minimal` now `[Java_17]`, `codegen` max `Java_17`; `Require-Capability` is `osgi.ee=JavaSE)(version=17)` for all published bundles.

<!-- fennec-agent -->
---
*This was written by an AI agent (Claude Code) operated by a project committer.
A human project lead reviews all agent contributions before merge.*