### PR TITLE
Bump base-version to 1.0.2 after the 1.0.1 release

### DIFF
--- a/cnf/ext/version.bnd
+++ b/cnf/ext/version.bnd
@@ -1,1 +1,1 @@
-base-version: 1.0.1
+base-version: 1.0.2

--- a/org.eclipse.fennec.emf.osgi.api/src-gen/org/eclipse/fennec/emf/osgi/constants/VersionConstant.java
+++ b/org.eclipse.fennec.emf.osgi.api/src-gen/org/eclipse/fennec/emf/osgi/constants/VersionConstant.java
@@ -19,6 +19,6 @@ package org.eclipse.fennec.emf.osgi.constants;
  */
 public class VersionConstant {
 
-	public static final String FENNECPROJECTS_EMF_VERSION = "1.0.1"; //$NON-NLS-1$
+	public static final String FENNECPROJECTS_EMF_VERSION = "1.0.2"; //$NON-NLS-1$
 	public static final String FENNECPROJECTS_EMF_MAJOR_VERSION = "1"; //$NON-NLS-1$
 }


### PR DESCRIPTION
Post-release step per `docs/eclipse-release-guide.md` §6: with the 1.0.1 release OBR as the new baseline, every changed bundle must version at least 1.0.2 — `snapshot` builds currently fail baselining without this bump.

- `cnf/ext/version.bnd`: `base-version` 1.0.1 → 1.0.2
- regenerated `VersionConstant.java`

Verified locally: `./gradlew build` green including baselining against the 1.0.1 OBR.

Note: PR #36 needs this on `snapshot` (plus a rebase) before its CI can go green.

<!-- fennec-agent -->
---
*This was written by an AI agent (Claude Code) operated by a project committer.
A human project lead reviews all agent contributions before merge.*