### PR TITLE
Keep released baseline artifacts out of resolve and codegen embedding

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -27,8 +27,25 @@ github-orga: eclipse-fennec
 
 maven-central: true
 
-# Baselining against the release OBR — provided by the fennec library.
-fennec-baselining: true
+# Baselining against the release OBR. TEMPORARY (see issue #41): the library's
+# baseline block is disabled and inlined here with 'tags=baseline', so the
+# resolver no longer considers the release OBR (untagged repos default to
+# 'resolve' and leak released bundles into resolve/buildpath lookups).
+# Revert to 'fennec-baselining: true' once the fennec bnd library tags its
+# Baseline repository itself.
+fennec-baselining: false
+
+-plugin.baseline: \
+	aQute.bnd.repository.osgi.OSGiRepository;\
+		locations	=https://raw.githubusercontent.com/${github-orga}/${github-project}/release-obr/index.xml;\
+		max.stale	=-1;\
+		poll.time	=-1;\
+		tags		=baseline;\
+		name		=Baseline
+
+-baselinerepo: Baseline
+-baseline: *
+-diffpackages: *;threshold=MINOR
 
 -groupid: org.eclipse.fennec.emf
     	

--- a/org.eclipse.fennec.emf.osgi.codegen/bnd.bnd
+++ b/org.eclipse.fennec.emf.osgi.codegen/bnd.bnd
@@ -26,7 +26,7 @@ src=${^src}
 	aQute.libg;version=latest,\
 	org.eclipse.fennec.emf.osgi;version=project,\
 	org.eclipse.uml2.codegen.ecore;version=latest,\
-	org.eclipse.fennec.emf.osgi.api
+	org.eclipse.fennec.emf.osgi.api;version=project
 
 -testpath: \
 	slf4j.api;version=latest, \


### PR DESCRIPTION
Fixes #41 (workspace side — the broken 1.0.1 codegen jar on Central additionally needs a 1.0.2 release, and the permanent fix belongs in the fennec bnd library).

## What

1. **`codegen/bnd.bnd`**: the `org.eclipse.fennec.emf.osgi.api` buildpath entry is now pinned with `;version=project`. `-conditionalpackage: org.eclipse.fennec.emf.*` embeds api packages from whatever jar satisfies that entry — unqualified, the released api from the Baseline OBR could win, which is exactly how codegen 1.0.1 shipped embedded Java-21 api-1.0.0 classes.
2. **`cnf/build.bnd`**: `fennec-baselining: false` + the library's baseline block inlined with **`tags=baseline`** on the Baseline `OSGiRepository`. Repositories without an explicit tag participate in resolution; the tag removes the release OBR from resolver consideration while `-baselinerepo: Baseline` (name lookup) keeps baselining fully functional. Marked TEMPORARY — revert once the fennec bnd library tags its repository itself.

## Verification

- Probe resolve requiring `api;version='[1.0.1,1.0.2)'` (a version only the Baseline OBR provides) now fails with `found []` → repo invisible to the resolver.
- `${def;-baseline}`/`${def;-baselinerepo}` still expand to `*`/`Baseline` in project context → baselining active.
- `./gradlew clean build` green, including the baseline checks against the 1.0.1 OBR.

<!-- fennec-agent -->
---
*This was written by an AI agent (Claude Code) operated by a project committer.
A human project lead reviews all agent contributions before merge.*