### PR TITLE
Issue 48 http error body discarded

### DIFF
--- a/cnf/ext/version.bnd
+++ b/cnf/ext/version.bnd
@@ -1,1 +1,1 @@
-base-version: 1.0.2
+base-version: 1.0.3

--- a/org.eclipse.fennec.emf.osgi.api/src-gen/org/eclipse/fennec/emf/osgi/constants/VersionConstant.java
+++ b/org.eclipse.fennec.emf.osgi.api/src-gen/org/eclipse/fennec/emf/osgi/constants/VersionConstant.java
@@ -19,6 +19,6 @@ package org.eclipse.fennec.emf.osgi.constants;
  */
 public class VersionConstant {
 
-	public static final String FENNECPROJECTS_EMF_VERSION = "1.0.2"; //$NON-NLS-1$
+	public static final String FENNECPROJECTS_EMF_VERSION = "1.0.3"; //$NON-NLS-1$
 	public static final String FENNECPROJECTS_EMF_MAJOR_VERSION = "1"; //$NON-NLS-1$
 }

--- a/org.eclipse.fennec.emf.osgi/src/org/eclipse/fennec/emf/osgi/urihandler/RestfulURIHandlerImpl.java
+++ b/org.eclipse.fennec.emf.osgi/src/org/eclipse/fennec/emf/osgi/urihandler/RestfulURIHandlerImpl.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -70,6 +71,8 @@ public class RestfulURIHandlerImpl extends URIHandlerImpl {
 	private static final String PROP_ECLASS = "EClass";
 	/** HTTP_PUT */
 	private static final String HTTP_PUT = "PUT";
+	/** Upper bound for the error body appended to exception messages */
+	private static final int MAX_ERROR_BODY_BYTES = 8 * 1024;
 	private static final Logger LOG = Logger.getLogger(RestfulURIHandlerImpl.class.getName());
 
 	/*
@@ -123,8 +126,7 @@ public class RestfulURIHandlerImpl extends URIHandlerImpl {
 						break;
 					}
 					default: {
-						throw new IOException(httpURLConnection.getRequestMethod() + ERROR_WITH_RESPONSE_CODE
-								+ responseCode);
+						throw httpError(httpURLConnection, responseCode, readErrorBody(in));
 					}
 					}
 				} finally {
@@ -187,10 +189,8 @@ public class RestfulURIHandlerImpl extends URIHandlerImpl {
 
 				@Override
 				public void close() throws IOException {
-					super.close();
-
 					int responseCode = httpURLConnection.getResponseCode();
-					httpURLConnection.disconnect();
+					IOException failure = null;
 					switch (responseCode) {
 					case HttpURLConnection.HTTP_OK:
 					case HttpURLConnection.HTTP_CREATED:
@@ -198,9 +198,15 @@ public class RestfulURIHandlerImpl extends URIHandlerImpl {
 						break;
 					}
 					default: {
-						throw new IOException(httpURLConnection.getRequestMethod() + ERROR_WITH_RESPONSE_CODE
-								+ responseCode);
+						// the wrapped stream is the error stream here; drain what the
+						// caller has not consumed before it is closed
+						failure = httpError(httpURLConnection, responseCode, readErrorBody(in));
 					}
+					}
+					super.close();
+					httpURLConnection.disconnect();
+					if (failure != null) {
+						throw failure;
 					}
 				}
 
@@ -236,7 +242,14 @@ public class RestfulURIHandlerImpl extends URIHandlerImpl {
 			throws IOException {
 		InputStream result = httpURLConnection.getErrorStream();
 		if (result == null) {
-			result = httpURLConnection.getInputStream();
+			if (httpURLConnection.getResponseCode() >= HttpURLConnection.HTTP_BAD_REQUEST) {
+				// error response without a body (e.g. with output streaming);
+				// getInputStream() would throw the raw JDK exception here, so let
+				// the callers report the failure from the status code instead
+				result = InputStream.nullInputStream();
+			} else {
+				result = httpURLConnection.getInputStream();
+			}
 		}
 		if (Boolean.TRUE.equals(options.get(EMFUriHandlerConstants.OPTIONS_LOG_RESPONSE))) {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -252,9 +265,46 @@ public class RestfulURIHandlerImpl extends URIHandlerImpl {
 		return result;
 	}
 
+	/**
+	 * Reads the HTTP error body from the given stream, capped at
+	 * {@link #MAX_ERROR_BODY_BYTES}. Never throws: the response body is
+	 * best-effort context and must not mask the status code.
+	 *
+	 * @param in the error stream, may be <code>null</code> or already partly
+	 *            consumed
+	 * @return the remaining body content, or an empty string
+	 */
+	private String readErrorBody(InputStream in) {
+		if (in == null) {
+			return "";
+		}
+		try {
+			return new String(in.readNBytes(MAX_ERROR_BODY_BYTES), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			return "";
+		}
+	}
+
+	/**
+	 * Creates the {@link IOException} for a non-2xx response, appending the error
+	 * body to the message if one is available
+	 *
+	 * @param httpURLConnection the connection that returned the error
+	 * @param responseCode      the HTTP status code
+	 * @param errorBody         the response body, may be empty
+	 * @return the exception to throw
+	 */
+	private IOException httpError(HttpURLConnection httpURLConnection, int responseCode, String errorBody) {
+		String message = httpURLConnection.getRequestMethod() + ERROR_WITH_RESPONSE_CODE + responseCode;
+		if (!errorBody.isBlank()) {
+			message += ": " + errorBody;
+		}
+		return new IOException(message);
+	}
+
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * org.eclipse.emf.ecore.resource.impl.URIHandlerImpl#delete(org.eclipse.emf.
 	 * common.util.URI, java.util.Map)
@@ -271,17 +321,20 @@ public class RestfulURIHandlerImpl extends URIHandlerImpl {
 					(Map<String, String>) options.get(EMFUriHandlerConstants.OPTION_HTTP_HEADERS));
 			httpURLConnection.setRequestMethod(HTTP_DELETE);
 			int responseCode = httpURLConnection.getResponseCode();
-			httpURLConnection.disconnect();
-			switch (responseCode) {
-			case HttpURLConnection.HTTP_OK:
-			case HttpURLConnection.HTTP_ACCEPTED:
-			case HttpURLConnection.HTTP_NO_CONTENT: {
-				break;
-			}
-			default: {
-				throw new IOException(
-						httpURLConnection.getRequestMethod() + ERROR_WITH_RESPONSE_CODE + responseCode);
-			}
+			try {
+				switch (responseCode) {
+				case HttpURLConnection.HTTP_OK:
+				case HttpURLConnection.HTTP_ACCEPTED:
+				case HttpURLConnection.HTTP_NO_CONTENT: {
+					break;
+				}
+				default: {
+					throw httpError(httpURLConnection, responseCode,
+							readErrorBody(httpURLConnection.getErrorStream()));
+				}
+				}
+			} finally {
+				httpURLConnection.disconnect();
 			}
 		} catch (RuntimeException exception) {
 			throw new Resource.IOWrappedException(exception);

--- a/org.eclipse.fennec.emf.osgi/test/org/eclipse/fennec/emf/osgi/urihandler/RestfulURIHandlerImplTest.java
+++ b/org.eclipse.fennec.emf.osgi/test/org/eclipse/fennec/emf/osgi/urihandler/RestfulURIHandlerImplTest.java
@@ -1,0 +1,130 @@
+/********************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Data In Motion Consulting - initial implementation
+ ********************************************************************/
+package org.eclipse.fennec.emf.osgi.urihandler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.fennec.emf.osgi.constants.EMFUriHandlerConstants;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Tests that {@link RestfulURIHandlerImpl} surfaces the HTTP error response
+ * body in the thrown {@link IOException} (see issue #48)
+ *
+ * @author Data In Motion
+ */
+public class RestfulURIHandlerImplTest {
+
+	private static final String ERROR_BODY = "{\"error\":\"validation failed\",\"field\":\"name\"}";
+
+	private HttpServer server;
+	private RestfulURIHandlerImpl handler;
+
+	@BeforeEach
+	public void setUp() throws IOException {
+		server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+		server.start();
+		handler = new RestfulURIHandlerImpl();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		server.stop(0);
+	}
+
+	private URI uri(String path) {
+		return URI.createURI("http://localhost:" + server.getAddress().getPort() + path);
+	}
+
+	private void respond(String path, int status, String body) {
+		server.createContext(path, exchange -> {
+			// drain the request body, otherwise the client may see a broken pipe
+			exchange.getRequestBody().readAllBytes();
+			byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(status, bytes.length == 0 ? -1 : bytes.length);
+			try (OutputStream out = exchange.getResponseBody()) {
+				out.write(bytes);
+			}
+		});
+	}
+
+	@Test
+	public void testCreateOutputStreamErrorBodyInException() throws IOException {
+		respond("/reject", 400, ERROR_BODY);
+		OutputStream out = handler.createOutputStream(uri("/reject"),
+				Map.of(EMFUriHandlerConstants.OPTION_HTTP_METHOD, "POST"));
+		out.write("payload".getBytes(StandardCharsets.UTF_8));
+		IOException exception = assertThrows(IOException.class, out::close);
+		assertTrue(exception.getMessage().contains("POST failed with HTTP response code 400"),
+				"unexpected message: " + exception.getMessage());
+		assertTrue(exception.getMessage().contains(ERROR_BODY), "error body missing: " + exception.getMessage());
+	}
+
+	@Test
+	public void testCreateInputStreamErrorBodyInException() throws IOException {
+		respond("/reject", 404, ERROR_BODY);
+		InputStream in = handler.createInputStream(uri("/reject"), Map.of());
+		IOException exception = assertThrows(IOException.class, in::close);
+		assertTrue(exception.getMessage().contains("GET failed with HTTP response code 404"),
+				"unexpected message: " + exception.getMessage());
+		assertTrue(exception.getMessage().contains(ERROR_BODY), "error body missing: " + exception.getMessage());
+	}
+
+	@Test
+	public void testDeleteErrorBodyInException() {
+		respond("/reject", 409, ERROR_BODY);
+		IOException exception = assertThrows(IOException.class, () -> handler.delete(uri("/reject"), Map.of()));
+		assertTrue(exception.getMessage().contains("DELETE failed with HTTP response code 409"),
+				"unexpected message: " + exception.getMessage());
+		assertTrue(exception.getMessage().contains(ERROR_BODY), "error body missing: " + exception.getMessage());
+	}
+
+	@Test
+	public void testEmptyErrorBodyKeepsPlainMessage() throws IOException {
+		respond("/empty", 500, "");
+		InputStream in = handler.createInputStream(uri("/empty"), Map.of());
+		IOException exception = assertThrows(IOException.class, in::close);
+		assertEquals("GET failed with HTTP response code 500", exception.getMessage());
+	}
+
+	@Test
+	public void testErrorBodyIsCapped() throws IOException {
+		respond("/huge", 400, "x".repeat(64 * 1024));
+		InputStream in = handler.createInputStream(uri("/huge"), Map.of());
+		IOException exception = assertThrows(IOException.class, in::close);
+		assertTrue(exception.getMessage().length() <= 8 * 1024 + 100,
+				"message not capped, length: " + exception.getMessage().length());
+	}
+
+	@Test
+	public void testSuccessfulRequestsStillWork() throws IOException {
+		respond("/ok", 200, "content");
+		try (InputStream in = handler.createInputStream(uri("/ok"), Map.of())) {
+			assertEquals("content", new String(in.readAllBytes(), StandardCharsets.UTF_8));
+		}
+	}
+}


### PR DESCRIPTION
Fixes #48. 
Add the http error response body into the IOException so when we get that we can understand what the cause of the error actually was.