### PR TITLE
fix(codegen): pack emf-merge.xml under templates/

### DIFF
--- a/org.eclipse.fennec.emf.osgi.codegen/bnd.bnd
+++ b/org.eclipse.fennec.emf.osgi.codegen/bnd.bnd
@@ -39,7 +39,7 @@ src=${^src}
 
 -includeresource.resource: \
 	/=resources,\
-	templates
+	templates/=templates/
 	#org.eclipse.jdt.core!/org/eclipse/jdt/internal/compiler/parser
 	
 -privatepackage.add: \

--- a/org.eclipse.fennec.emf.osgi.codegen/templates/emf-merge.xml
+++ b/org.eclipse.fennec.emf.osgi.codegen/templates/emf-merge.xml
@@ -85,6 +85,20 @@
     targetPut="Type/addSuperInterface"/>
 
   <merge:pull 
+    sourceGet="Record/getTypeParameters"
+    targetMarkup="^lastgen$|^gen$|^modifiable$|^model$"
+    targetPut="Record/setTypeParameters"/>
+  <merge:pull 
+    sourceGet="Record/getSuperInterfaces"
+    sourceTransfer="(\s*@\s*extends|\s*@\s*implements)(.*?)(?:&lt;!--|(?:\n\r?|\r\n?))"
+    targetMarkup="^lastgen$|^gen$|^modifiable$|^model$"
+    targetPut="Record/addSuperInterface"/>
+  <merge:pull 
+    sourceGet="Record/getRecordComponents"
+    targetMarkup="^lastgen$|^gen$|^modifiable$|^model$"
+    targetPut="Record/setRecordComponents"/>
+
+  <merge:pull 
     sourceGet="Enum/getSuperInterfaces"
     sourceTransfer="(\s*@\s*extends|\s*@\s*implements)(.*?)(?:&lt;!--|(?:\n\r?|\r\n?))"
     targetMarkup="^lastgen$|^gen$|^modifiable$|^model$"


### PR DESCRIPTION
Fixes #68

Der Generator warf bei jedem Lauf eine `MalformedURLException` aus `JControlModel.initialize`, weil `mergeRulesURI` `null` war — EMF sucht `<jar-root>/templates/emf-merge.xml`, im Fat-Jar lag die Datei aber im Root. Der Build blieb dabei grün, weil EMF die Exception abfängt und nur nach stderr loggt. Details im Issue.

## Änderungen

**`org.eclipse.fennec.emf.osgi.codegen/bnd.bnd`** — `templates` → `templates/=templates/`

Die Assignment-Form verhindert das Abflachen. Im Jar liegt jetzt `templates/emf-merge.xml` und `templates/model/*.javajet` statt `emf-merge.xml` und `model/` im Root.

**`templates/emf-merge.xml`** — die drei fehlenden `Record`-Regeln

Übernommen aus dem tatsächlich aufgelösten `org.eclipse.emf.codegen.ecore:2.44.0` (`cnf/central.mvn:94`), byte-identisch mit EMF master. Der Diff ist rein additiv, es gab keine eigenen Anpassungen zu erhalten. Kompatibilität: Der JMerge-Record-Support (`JRecord`, `ASTJRecord`) steckt in `org.eclipse.emf.codegen`, und unsere Laufzeitversion 2.27.0 (`cnf/central.mvn:95`) ist genau die, die ihn einführte.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `MalformedURLException` / `JControlModel` im Generate-Log | 0 Treffer (vorher: Stacktrace pro Modell) |
| Exceptions insgesamt im Log | keine |
| `example.model.basic` src-gen | 47 Dateien, identisch zu vorher |
| `example.model.extended` src-gen | 28 Dateien, identisch |
| `metadata` src-gen | 35 Dateien, identisch |
| `codegen` + `codegen.test` Tests | BUILD SUCCESSFUL |
| Jar-Layout | `templates/…` korrekt, keine Reste im Root |

Alle drei Modelle mit `--rerun-tasks` frisch generiert, `diff -rq` gegen die Sicherung ist leer. Der generierte Code ändert sich nicht — erwartungsgemäß, weil ohne Merge-Ziel nichts zu mergen war.

## Nicht Teil dieses PRs

In `metadata/bnd.bnd:39`, `example.model.extended/bnd.bnd:28` und `example.model.basic/bnd.bnd:24` steht `clean=false`. Das Attribut heißt in bnd aber `clear` (`ProjectInstructions.java:66`), die Zeile ist also wirkungslos und `src-gen/` wird vor jedem Lauf geleert. Damit laufen die Merge-Regeln weiterhin praktisch leer mit — sie sind jetzt nur korrekt verfügbar. Ob wir auf `clear=false` umstellen wollen, ist eine Verhaltensänderung und sollte separat entschieden werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
