### PR TITLE
Place derived registry content only on the model version it names (#81)

### DIFF
--- a/docs-site/docs/.vitepress/config.mts
+++ b/docs-site/docs/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitepress'
+import { withMermaid } from 'vitepress-plugin-mermaid'
 import { GUIDES, slugFor } from '../../guides.mjs'
 
 // Per-project docs are served under a versioned sub-path, matching the org
@@ -41,7 +42,10 @@ const navGuides = groupOrder.map((name) => ({
   link: byGroup.get(name)[0].link,
 }))
 
-export default defineConfig({
+// withMermaid renders ```mermaid fences the guides use for the mechanism diagrams. The
+// sources live in the repository and GitHub renders those fences natively; this keeps the
+// published site equivalent instead of showing the diagram source as a code block.
+export default withMermaid(defineConfig({
   title: 'Fennec EMF OSGi',
   description:
     'The Eclipse Modeling Framework in pure OSGi environments — ResourceSets, EPackages and ResourceFactories as dynamic OSGi services, without Eclipse PDE or Equinox dependencies.',
@@ -99,4 +103,4 @@ export default defineConfig({
       copyright: 'Copyright © Eclipse Foundation and contributors',
     },
   },
-})
+}))

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -8,7 +8,9 @@
       "name": "fennec-emf-osgi-docs",
       "version": "1.0.0",
       "devDependencies": {
+        "mermaid": "^11.16.1",
         "vitepress": "^1.6.3",
+        "vitepress-plugin-mermaid": "^2.0.17",
         "vue": "^3.5.13"
       }
     },
@@ -270,6 +272,20 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -319,6 +335,20 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@docsearch/css": {
       "version": "3.8.2",
@@ -779,12 +809,59 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz",
+      "integrity": "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@braintree/sanitize-url": "^6.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
+        "d3": "^7.0.0",
+        "khroma": "^2.0.0",
+        "non-layered-tidy-tree-layout": "^2.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap/node_modules/@braintree/sanitize-url": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -1223,10 +1300,301 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1275,6 +1643,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1295,6 +1671,17 @@
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -1641,6 +2028,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
@@ -1657,12 +2054,580 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -1688,6 +2653,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/emoji-regex-xs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
@@ -1707,6 +2682,18 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1779,6 +2766,13 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -1835,6 +2829,40 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -1847,6 +2875,53 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1864,6 +2939,19 @@
       "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
@@ -1885,6 +2973,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.1",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.1.tgz",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark-util-character": {
@@ -2014,6 +3132,14 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/non-layered-tidy-tree-layout": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
@@ -2025,6 +3151,20 @@
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
       }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -2039,6 +3179,24 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.19",
@@ -2133,6 +3291,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
@@ -2177,6 +3342,33 @@
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -2249,6 +3441,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -2269,6 +3468,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -2278,6 +3487,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/unist-util-is": {
@@ -2351,6 +3570,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -2483,6 +3716,20 @@
         "postcss": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitepress-plugin-mermaid": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-mermaid/-/vitepress-plugin-mermaid-2.0.17.tgz",
+      "integrity": "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@mermaid-js/mermaid-mindmap": "^9.3.0"
+      },
+      "peerDependencies": {
+        "mermaid": "10 || 11",
+        "vitepress": "^1.0.0 || ^1.0.0-alpha"
       }
     },
     "node_modules/vue": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -13,7 +13,9 @@
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
+    "mermaid": "^11.16.1",
     "vitepress": "^1.6.3",
+    "vitepress-plugin-mermaid": "^2.0.17",
     "vue": "^3.5.13"
   }
 }

--- a/docs/eobject-registry-guide.md
+++ b/docs/eobject-registry-guide.md
@@ -49,7 +49,9 @@ sync semantics** (a source's failure or death never touches other sources' conte
 the **technical origin** — the input channel that wrote the entry (the provider
 instance name, e.g. `mapping-files`, `atlas-jena`) — and scopes `sync`. It is *not*
 the model origin: model anchoring goes into the entry `properties` under the existing
-conventions `emf.nsURI` / `emf.fingerprint`. Example — a sensinact mapping fetched
+conventions `emf.nsURI` / `emf.fingerprint` — and `emf.fingerprint` is more than
+provenance, it decides which model versions the content reaches (see
+[the metadata bridge](#the-metadata-bridge)). Example — a sensinact mapping fetched
 from an atlas: key = the mapping's `mid`, source = `atlas-jena`, properties =
 `emf.nsURI`, `emf.fingerprint`, `atlas.scope`, `atlas.registry`, `atlas.object.id`.
 
@@ -125,14 +127,37 @@ EObjectRegistry registry = writer.getRegistry();   // fully loaded when this ret
 
 The bridge makes `MetadataService.getClassAspect(eClass, typeId)` the uniform,
 model-anchored read surface for registry content. It is both an
-`EObjectRegistryListener` (content changes flow onto the trees of every live model
-version) and a `MetadataHandler` (new fingerprint trees get the current content
+`EObjectRegistryListener` (content changes flow onto the trees of the model versions an
+entry belongs to) and a `MetadataHandler` (new fingerprint trees get the current content
 re-contributed).
 
 **Anchor resolution** is domain-specific and pluggable (`AspectAnchorResolver`,
 selected via `anchorResolver.target`): the default anchors at the content's own
 `eClass()`; a sensinact resolver anchors a mapping at its
 `ProviderMapping.getProviderClasses()` — one entry, many anchors.
+
+**Which model versions an entry reaches** is decided by the entry, through
+`emf.fingerprint`:
+
+- **No fingerprint ⇒ version-independent.** The content goes onto *every* live version
+  of its anchor's nsURI. This is what makes a version bump cost nothing for mappings,
+  profiles and resolved configuration.
+- **A fingerprint ⇒ derived, pinned to that version.** The content goes onto that
+  version and no other, and waits if the version is not deployed yet.
+
+> **Content that holds references into the model MUST carry `emf.fingerprint`.** The
+> aspect content is copied with `EcoreUtil.copy`, which copies containment and leaves
+> non-containment references pointing at the **originals**. An artifact derived from one
+> package instance — compiled OCL holding its resolved `EStructuralFeature` and
+> `EClassifier` instances is the real case — would, on a foreign version's tree, navigate
+> the wrong package: failing at `eGet` with dynamic EMF, or quietly resolving by name and
+> answering from the wrong model with generated code. Naming the version is what prevents
+> it (issue #81).
+
+Because placement is narrowed this way, **placement is also provenance**: the
+`modelFingerprint` of the `PackageMetadata` containing an aspect is the fingerprint of
+the package its content was built from. A pinned entry whose version is not live is
+logged and stays pending in the registry.
 
 **Boundaries** (deliberate):
 
@@ -166,9 +191,22 @@ class is structurally impossible here.*
 
 **3. The model version bump.** A second, diverging version of the sensor model
 registers (same nsURI, new fingerprint) while the first stays live. The new version
-starts with an empty tree — the bridge re-contributes, both versions answer the
-lookup. *Problem solved: fingerprint identity does not silently drop content on
-re-registration or version bumps.*
+starts with an empty tree — the bridge re-contributes, and for version-independent
+content both versions answer the lookup. *Problem solved: fingerprint identity does not
+silently drop content on re-registration or version bumps.*
+
+**3b. The derived artifact at a version bump.** The same bump, but the entry carries
+`emf.fingerprint` — compiled OCL, derived from one package instance. It stays on the
+version it names; the new version does **not** get a copy that would navigate the old
+package's features, and the authored, version-independent mappings next to it keep
+spanning both versions. *Problem solved: the read face cannot reintroduce the
+cross-version mix-up that fingerprint identity exists to prevent.*
+
+**3c. The derived artifact ahead of its model.** The compiler ran against a version that
+is not deployed yet (a staged rollout, an atlas that already knows the next model). The
+entry names that version, waits, and lands the moment it registers — the replay of case
+2, narrowed to one version instead of all of them. *Problem solved: pinning costs nothing
+in start ordering.*
 
 **4. The dynamic source updates.** An atlas client pushes a corrected mapping under a
 key the files provided initially: the registry entry updates (last write wins across
@@ -207,7 +245,8 @@ plane.
 | `emf.eobject.registry.name` | registry services, listener whiteboard services, bridge config | the registry instance name |
 | `emf.eobject.provider.name` | provider services | selected by `initialProvider.target` |
 | `emf.eobject.registry.content.types` | registry services (optional) | declared content types for discovery |
-| `emf.nsURI`, `emf.fingerprint` | entry properties | model anchoring of an entry |
+| `emf.nsURI` | entry properties | the model the entry's content belongs to |
+| `emf.fingerprint` | entry properties | the **model version** the content was derived from. Present ⇒ the aspect is placed on that version only; absent ⇒ version-independent, placed on every live version. Mandatory for content holding references into the model. |
 | `file.location` | entry properties (file provider) | absolute path the entry was loaded from |
 
 Constants: `EObjectRegistryConstants` (registry bundle), `FileEObjectProvider.PROP_*`.

--- a/docs/eobject-registry-guide.md
+++ b/docs/eobject-registry-guide.md
@@ -136,8 +136,13 @@ selected via `anchorResolver.target`): the default anchors at the content's own
 `eClass()`; a sensinact resolver anchors a mapping at its
 `ProviderMapping.getProviderClasses()` — one entry, many anchors.
 
-**Which model versions an entry reaches** is decided by the entry, through
-`emf.fingerprint`:
+### Which model versions an entry reaches
+
+One nsURI can have several live model versions at the same time — a draft next to an
+approved stage, a bumped model next to the one consumers still hold. Each is its own
+`PackageMetadata` tree, keyed by [fingerprint](model-fingerprint-guide.md). So when the
+bridge places registry content as an aspect, it has to decide **which of those trees** the
+content belongs on. The entry decides, through `emf.fingerprint`:
 
 - **No fingerprint ⇒ version-independent.** The content goes onto *every* live version
   of its anchor's nsURI. This is what makes a version bump cost nothing for mappings,
@@ -149,34 +154,148 @@ selected via `anchorResolver.target`): the default anchors at the content's own
   single-element array or collection (the shape a value takes when properties are copied
   from service properties or Configurator JSON) is unwrapped.
 
-**Legacy models advertise no fingerprint — that changes nothing here.** Metadata identity
-is *computed*: `MetadataService` fingerprints every version it registers and treats a
-supplied value as context, never as truth. A producer pinning derived content against a
-legacy model therefore reads the computed value —
-`metadataService.getPackageMetadata(ePackage).get().getModelFingerprint()`, or
-`FingerprintHelper.fingerprint(ePackage)` before registration — instead of a bundle
-property, and gets the same guarantee as for a model that advertises one.
+```mermaid
+flowchart LR
+  subgraph REG["EObject registry: sensinact-mappings"]
+    A["entry temp-mapping<br/>no emf.fingerprint<br/><i>authored mapping</i>"]
+    B["entry temp-ocl@fp-v2<br/>emf.fingerprint = fp-v2<br/><i>compiled OCL</i>"]
+  end
 
-> **Content that holds references into the model MUST carry `emf.fingerprint`.** The
-> aspect content is copied with `EcoreUtil.copy`, which copies containment and leaves
-> non-containment references pointing at the **originals**. An artifact derived from one
-> package instance — compiled OCL holding its resolved `EStructuralFeature` and
-> `EClassifier` instances is the real case — would, on a foreign version's tree, navigate
-> the wrong package: failing at `eGet` with dynamic EMF, or quietly resolving by name and
-> answering from the wrong model with generated code. Naming the version is what prevents
-> it (issue #81).
+  subgraph MS["MetadataService — one tree per model version of http://…/sensors"]
+    T1["fp-v1<br/>TemperatureSensor"]
+    T2["fp-v2<br/>TemperatureSensor"]
+    T3["fp-v3<br/>TemperatureSensor"]
+  end
+
+  A --> T1
+  A --> T2
+  A --> T3
+  B --> T2
+  B -. "never" .-> T1
+  B -. "never" .-> T3
+```
+
+A consumer never sees this decision. It holds an `EClass` and asks
+`getClassAspect(eClass, typeId)`; because the `EClass` instance belongs to exactly one
+version, it gets that version's answer — the authored mapping on all three, the compiled
+OCL only on `fp-v2`.
+
+#### Why pinning matters: what a copy carries
+
+`AspectEntry#content` is a containment slot, so the bridge stores a **copy** of the
+registry object (`EcoreUtil.copy`) rather than stealing the live object out of its
+resource. That copy is deep for containment — and it leaves every **non-containment**
+reference pointing at the **original** target. For authored content that holds no model
+references, this is invisible. For a *derived* artifact it is the whole story: compiled OCL
+holds the `EStructuralFeature` and `EClassifier` instances it resolved against while
+compiling.
+
+```mermaid
+flowchart TB
+  subgraph V1["EPackage instance of fp-v1"]
+    F1["EAttribute measured<br/>(v1 instance)"]
+  end
+  subgraph V2["EPackage instance of fp-v2"]
+    F2["EAttribute measured<br/>(v2 instance)"]
+  end
+
+  SRC["compiled OCL<br/>in the registry<br/><i>compiled against v1</i>"] --> F1
+
+  subgraph T2["tree fp-v2 — where the copy would land unpinned"]
+    CP["copy of the compiled OCL<br/>sitting on v2's ClassMetadata"]
+  end
+
+  SRC -. "EcoreUtil.copy" .-> CP
+  CP -->|"reference survives the copy"| F1
+  CP -. "what a reader expects" .-x F2
+```
+
+The copy sits on v2's tree and navigates **v1's** features. Two failure shapes follow, and
+neither is loud:
+
+| Model style | What happens |
+|---|---|
+| Dynamic EMF (`EcoreUtil.create`, loaded `.ecore`) | `eGet` with a feature that is not this class's feature → `IllegalArgumentException` at the first evaluation |
+| Generated code | the feature may resolve **by name** and quietly answer from the wrong model version — a wrong value, no exception |
+
+> **Content that holds references into the model MUST carry `emf.fingerprint`.** Naming
+> the version is what keeps the copy and its references on the same version (issue #81).
+> Pinning is not an optimization; for derived content it is the correctness condition.
 
 Because placement is narrowed this way, **placement is also provenance**: the
-`modelFingerprint` of the `PackageMetadata` containing an aspect is the fingerprint of
-the package its content was built from. An entry that reaches no tree although its nsURI
-*is* deployed — it names a version that is not live, or the named version dropped the
-anchor class — is logged and stays pending in the registry. A cold start with no version
-of the nsURI live yet stays quiet: that is the normal state, not a suspicion.
+`modelFingerprint` of the `PackageMetadata` containing an aspect *is* the fingerprint of
+the package its content was built from. There is no second bookkeeping to keep in sync.
 
-**Keys are flat per registry.** If several model versions each contribute their own
-derived artifact, the entry keys must differ per version (e.g. `<id>@<fingerprint>`).
-Otherwise the second contribution overwrites the first — last write wins, logged, one
-entry left. The fingerprint governs *placement*, not key identity.
+#### Producing derived content: the order-free shape
+
+Derive from the model, then push into the registry with the version named. The bridge does
+the rest — including the case where the model is not there yet.
+
+```java
+@Component
+public class OclCompiler {
+
+    @Reference(target = "(emf.eobject.registry.name=compiled-ocl)")
+    private EObjectRegistryWriter registry;
+
+    /** One EPackage service per live model version, each carrying its fingerprint. */
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    void addModel(EPackage ePackage, Map<String, Object> properties) {
+        String fingerprint = (String) properties.get(EMFNamespaces.EMF_MODEL_FINGERPRINT);
+        for (EClass eClass : classesOf(ePackage)) {
+            EObject compiled = compile(eClass);       // resolves against THIS instance
+            registry.put("ocl-compiler",
+                    eClass.getName() + "@" + fingerprint,   // key carries the version
+                    compiled,
+                    Map.of(EMFNamespaces.EMF_MODEL_NSURI, ePackage.getNsURI(),
+                           EMFNamespaces.EMF_MODEL_FINGERPRINT, fingerprint));
+        }
+    }
+
+    void removeModel(EPackage ePackage, Map<String, Object> properties) {
+        // leaving the entries in place is fine: they are pinned, so they simply go pending
+        // until that version returns. Remove them if the memory matters.
+    }
+}
+```
+
+Two things in that snippet are the whole convention:
+
+**The key carries the version.** Registry keys are flat and unique *per registry*, so if
+three versions each contribute an artifact for `TemperatureSensor`, three distinct keys are
+needed. With one key the second `put` overwrites the first — last write wins, logged, one
+entry left. `emf.fingerprint` governs *placement*, never key identity.
+
+**The fingerprint comes from the model, not from a guess.** Read it from the `EPackage`
+service property, or compute it — `metadataService.getPackageMetadata(ePackage)` →
+`getModelFingerprint()`, or `FingerprintHelper.fingerprint(ePackage)` before any
+registration. Both give the same value.
+
+> **Do not derive inside `MetadataHandler.onPackageRegistered` and push from there.** The
+> new tree is published only *after* all handlers ran, and handlers run in registration
+> order — so whether the bridge sees your entry for the tree being built depends on wiring
+> order. Reacting to `EPackage` services, as above, has no such dependency: the bridge's
+> replay places the content whenever the tree exists, before or after.
+
+#### Legacy models without an advertised fingerprint
+
+A model generated before the scheme existed, or a plain `.ecore` loaded at runtime,
+advertises no `emf.fingerprint`. That changes nothing here, because metadata identity is
+**computed**: `MetadataService` fingerprints every version it registers and treats a
+supplied value as context, never as truth. Read the computed value and pin against it —
+a legacy model gets exactly the same guarantee as one that advertises its fingerprint.
+
+#### When content reaches nothing
+
+| Situation | Behaviour |
+|---|---|
+| No version of the nsURI is live yet (cold start, model bundle still starting) | silent — normal, the replay places the content on registration |
+| The named version is not among the live ones | logged, entry stays pending in the registry |
+| The named version is live but dropped the anchor class | logged, nothing placed |
+| The entry names no version and no live version carries the anchor class | logged |
+
+The rule behind the table: narrowing trades a silent *misplacement* for a silent
+*absence*, so an absence that is not simply "too early" is reported.
 
 **Boundaries** (deliberate):
 
@@ -226,6 +345,33 @@ is not deployed yet (a staged rollout, an atlas that already knows the next mode
 entry names that version, waits, and lands the moment it registers — the replay of case
 2, narrowed to one version instead of all of them. *Problem solved: pinning costs nothing
 in start ordering.*
+
+```mermaid
+sequenceDiagram
+    participant P as producer (atlas/compiler)
+    participant R as EObjectRegistry
+    participant B as RegistryMetadataBridge
+    participant M as MetadataService
+
+    Note over M: only fp-v1 is live
+    P->>R: put(key, artifact, {emf.fingerprint: fp-v2})
+    R->>B: entryAdded
+    B->>M: getPackageMetadataVersions(nsURI)
+    M-->>B: [fp-v1]
+    Note over B: fp-v1 ≠ fp-v2 → nothing placed,<br/>logged, entry stays in the registry
+
+    Note over M: the v2 model bundle starts
+    M->>M: build tree fp-v2
+    M->>B: onPackageRegistered(fp-v2)
+    Note over B: the entry names this version → place
+    B->>M: aspect on fp-v2 / TemperatureSensor
+    M->>M: publish tree fp-v2
+
+    Note over M: a consumer holding a v2 EClass now gets the artifact,<br/>a consumer holding a v1 EClass never does
+```
+
+The tree is published only *after* the handlers ran, so no reader can ever observe a
+version whose aspects are still missing.
 
 **4. The dynamic source updates.** An atlas client pushes a corrected mapping under a
 key the files provided initially: the registry entry updates (last write wins across

--- a/docs/eobject-registry-guide.md
+++ b/docs/eobject-registry-guide.md
@@ -144,6 +144,18 @@ selected via `anchorResolver.target`): the default anchors at the content's own
   profiles and resolved configuration.
 - **A fingerprint ⇒ derived, pinned to that version.** The content goes onto that
   version and no other, and waits if the version is not deployed yet.
+- **A blank or multi-valued fingerprint states no version** and is read as unknown, never
+  as a mismatch — the rule `EPackage#fingerprint()` lays down for the whole contract. A
+  single-element array or collection (the shape a value takes when properties are copied
+  from service properties or Configurator JSON) is unwrapped.
+
+**Legacy models advertise no fingerprint — that changes nothing here.** Metadata identity
+is *computed*: `MetadataService` fingerprints every version it registers and treats a
+supplied value as context, never as truth. A producer pinning derived content against a
+legacy model therefore reads the computed value —
+`metadataService.getPackageMetadata(ePackage).get().getModelFingerprint()`, or
+`FingerprintHelper.fingerprint(ePackage)` before registration — instead of a bundle
+property, and gets the same guarantee as for a model that advertises one.
 
 > **Content that holds references into the model MUST carry `emf.fingerprint`.** The
 > aspect content is copied with `EcoreUtil.copy`, which copies containment and leaves
@@ -156,8 +168,15 @@ selected via `anchorResolver.target`): the default anchors at the content's own
 
 Because placement is narrowed this way, **placement is also provenance**: the
 `modelFingerprint` of the `PackageMetadata` containing an aspect is the fingerprint of
-the package its content was built from. A pinned entry whose version is not live is
-logged and stays pending in the registry.
+the package its content was built from. An entry that reaches no tree although its nsURI
+*is* deployed — it names a version that is not live, or the named version dropped the
+anchor class — is logged and stays pending in the registry. A cold start with no version
+of the nsURI live yet stays quiet: that is the normal state, not a suspicion.
+
+**Keys are flat per registry.** If several model versions each contribute their own
+derived artifact, the entry keys must differ per version (e.g. `<id>@<fingerprint>`).
+Otherwise the second contribution overwrites the first — last write wins, logged, one
+entry left. The fingerprint governs *placement*, not key identity.
 
 **Boundaries** (deliberate):
 

--- a/docs/metadata-service-guide.md
+++ b/docs/metadata-service-guide.md
@@ -66,16 +66,50 @@ that ambiguity matters.
 This is also why a `FingerprintService` is a mandatory collaborator rather than a nicety: it
 computes the key everything else is filed under.
 
-**One model version can arrive as several Java instances.** A generated `EPackage` and the
-same model loaded from its `.ecore` produce the same fingerprint by design — the equivalence
-gate asserts it — so registering both deduplicates onto one tree. Element lookups
-(`getClassMetadata`, `getFeatureMetadata`, `getOperationMetadata`, and the `get…Aspect` calls
-on top of them) are keyed by instance for speed, but instance identity is only a cache key:
-an `EClass` of a second, structurally equal instance resolves to the shared tree instead of to
-nothing. The correspondence is exact, not a guess — classifier and feature names are unique
-within their scope, and operations correspond by declared position, which equal fingerprints
-guarantee. Diverging instances are unaffected: they are separate versions and each keeps
-resolving to its own.
+### One model version can arrive as several Java instances
+
+This is the counterpart of the rule above, and it surprises people the first time. A
+generated `EPackage` and the same model loaded from its `.ecore` are **two Java objects of
+one model version**: they produce the same fingerprint by design — the
+[equivalence gate](model-fingerprint-guide.md) asserts exactly this — so registering both
+deduplicates onto one tree with a liveness count of two.
+
+Both instances are perfectly normal in OSGi at the same time: a generated model bundle is
+active, and a tool or an atlas client loads the same `.ecore` into a `ResourceSet` for
+inspection. Objects then exist whose `eClass()` comes from the *loaded* instance while all
+metadata was filed under the *generated* one.
+
+```mermaid
+flowchart LR
+  G["EPackage instance A<br/><i>generated code</i>"] --> FP{{"fingerprint<br/>fp-v1"}}
+  L["EPackage instance B<br/><i>loaded .ecore</i>"] --> FP
+  FP --> T["one PackageMetadata tree<br/>ClassMetadata, aspects, index"]
+
+  A2["getClassMetadata(A.Person)"] -->|"indexed by instance"| T
+  B2["getClassMetadata(B.Person)"] -->|"falls back via fingerprint"| T
+```
+
+Element lookups (`getClassMetadata`, `getFeatureMetadata`, `getOperationMetadata`, and the
+`get…Aspect` calls built on them) are keyed by instance for speed, but instance identity is
+only a cache key — never the identity of the model. An `EClass` of the second instance
+therefore resolves to the shared tree instead of to nothing, which is what makes
+model-anchored content (an `AspectEntry` from an
+[EObject registry](eobject-registry-guide.md), a codec aspect) answerable no matter which
+instance a consumer happens to hold.
+
+The correspondence is exact rather than a guess: equal fingerprints mean equal structure,
+classifier and feature names are unique within their scope, and operations correspond by
+declared position — which the fingerprint also pins, since it hashes the declared order.
+
+Two boundaries are worth knowing:
+
+- **Diverging instances are untouched.** Different content means different fingerprints,
+  hence separate versions, and each `EClass` keeps resolving to its own tree. The fallback
+  is per model version, never per name.
+- **Nothing is memoized.** A memo would have to be invalidated when a version is withdrawn,
+  and a stale one would answer with the metadata of a version that is no longer live. The
+  common path — one instance, or the instance that built the tree — is still a single map
+  lookup; only the miss pays for the fallback.
 
 ### Push and pull are both first-class
 

--- a/docs/metadata-service-guide.md
+++ b/docs/metadata-service-guide.md
@@ -66,6 +66,17 @@ that ambiguity matters.
 This is also why a `FingerprintService` is a mandatory collaborator rather than a nicety: it
 computes the key everything else is filed under.
 
+**One model version can arrive as several Java instances.** A generated `EPackage` and the
+same model loaded from its `.ecore` produce the same fingerprint by design — the equivalence
+gate asserts it — so registering both deduplicates onto one tree. Element lookups
+(`getClassMetadata`, `getFeatureMetadata`, `getOperationMetadata`, and the `get…Aspect` calls
+on top of them) are keyed by instance for speed, but instance identity is only a cache key:
+an `EClass` of a second, structurally equal instance resolves to the shared tree instead of to
+nothing. The correspondence is exact, not a guess — classifier and feature names are unique
+within their scope, and operations correspond by declared position, which equal fingerprints
+guarantee. Diverging instances are unaffected: they are separate versions and each keeps
+resolving to its own.
+
 ### Push and pull are both first-class
 
 There are two ways a tree comes into existence, and the difference matters for anything that

--- a/org.eclipse.fennec.emf.osgi.eobject.registry.itest/src/org/eclipse/fennec/emf/osgi/eobject/registry/itest/EObjectRegistryIntegrationTest.java
+++ b/org.eclipse.fennec.emf.osgi.eobject.registry.itest/src/org/eclipse/fennec/emf/osgi/eobject/registry/itest/EObjectRegistryIntegrationTest.java
@@ -29,6 +29,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.fennec.emf.osgi.ResourceSetFactory;
+import org.eclipse.fennec.emf.osgi.constants.EMFNamespaces;
 import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistry;
 import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistryConstants;
 import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistryEntry;
@@ -250,6 +251,56 @@ public class EObjectRegistryIntegrationTest {
 				"itest.person.aspect");
 		Person snapshot = (Person) aspect.orElseThrow().getContent();
 		assertThat(snapshot.getFirstName()).isEqualTo("Emil");
+	}
+
+	/**
+	 * The fingerprint guard against the fingerprints the running framework really computes
+	 * (issue #81): an entry naming the live model version is placed, an entry naming any
+	 * other version is not - it stays in the registry, pending, and must not displace the
+	 * aspect that legitimately sits on the anchor.
+	 */
+	@Test
+	public void testPinnedEntryReachesOnlyTheLiveModelVersion(@InjectService MetadataService metadataService)
+			throws Exception {
+		Path dir = Files.createTempDirectory("eobject-registry-itest");
+		writePersonFixture(dir, "persons.basic", "Emil");
+		createProviderConfig("persons-pinned-files", dir);
+		createRegistryConfig("persons-pinned", "persons-pinned-files");
+		createBridgeConfig("persons-pinned", "itest.pinned.aspect");
+
+		awaitTrue(() -> metadataService.getClassAspect(BasicPackage.Literals.PERSON, "itest.pinned.aspect").isPresent(),
+				"the bridge is up on the authored content");
+		String liveFingerprint = metadataService.getPackageMetadata(BasicPackage.eINSTANCE).orElseThrow()
+				.getModelFingerprint();
+
+		ServiceTracker<EObjectRegistryWriter, EObjectRegistryWriter> writerTracker = tracker(
+				EObjectRegistryWriter.class, "persons-pinned");
+		try {
+			EObjectRegistryWriter writer = writerTracker.waitForService(10_000);
+			assertThat(writer).isNotNull();
+
+			Person derived = BasicFactory.eINSTANCE.createPerson();
+			derived.setFirstName("Pinned");
+			writer.put("compiler", "Pinned", derived, Map.of(EMFNamespaces.EMF_MODEL_FINGERPRINT, liveFingerprint));
+			awaitTrue(() -> "Pinned".equals(aspectFirstName(metadataService, "itest.pinned.aspect")),
+					"an entry naming the live version is placed");
+
+			Person foreign = BasicFactory.eINSTANCE.createPerson();
+			foreign.setFirstName("ForeignVersion");
+			writer.put("compiler", "Foreign", foreign, Map.of(EMFNamespaces.EMF_MODEL_FINGERPRINT,
+					"fp1:0000000000000000000000000000000000000000000000000000000000000000"));
+
+			assertThat(writer.getRegistry().get("Foreign")).as("kept in the registry, pending its version").isPresent();
+			assertThat(aspectFirstName(metadataService, "itest.pinned.aspect"))
+					.as("an entry naming another version never reaches this tree").isEqualTo("Pinned");
+		} finally {
+			writerTracker.close();
+		}
+	}
+
+	private String aspectFirstName(MetadataService metadataService, String typeId) {
+		return metadataService.getClassAspect(BasicPackage.Literals.PERSON, typeId)
+				.map(aspect -> ((Person) aspect.getContent()).getFirstName()).orElse(null);
 	}
 
 	private void awaitTrue(BooleanSupplier condition, String description) throws InterruptedException {

--- a/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/src/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/RegistryMetadataBridge.java
+++ b/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/src/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/RegistryMetadataBridge.java
@@ -12,6 +12,8 @@
  ********************************************************************/
 package org.eclipse.fennec.emf.osgi.eobject.registry.metadata;
 
+import static org.eclipse.fennec.emf.osgi.annotation.provide.EPackage.FINGERPRINT_ATTRIBUTE;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -41,10 +43,19 @@ import org.eclipse.fennec.emf.osgi.model.metadata.PackageMetadata;
  * libraries and codec aspects alike.
  * <p>
  * The bridge is <b>both</b> an {@link EObjectRegistryListener} (content changes flow
- * onto the trees of every live model version) and a {@link MetadataHandler} (a newly
- * registered model version - a new fingerprint tree - gets the current content
- * re-contributed; without this, a re-registered or bumped package would silently lose
- * its aspects, because metadata identity is the fingerprint, not the nsURI).
+ * onto the trees of the model versions the content belongs to) and a
+ * {@link MetadataHandler} (a newly registered model version - a new fingerprint tree -
+ * gets the current content re-contributed; without this, a re-registered or bumped
+ * package would silently lose its aspects, because metadata identity is the fingerprint,
+ * not the nsURI).
+ * <p>
+ * <b>Which versions an entry reaches</b> is decided by the entry itself, see
+ * {@link #belongsTo(EObjectRegistryEntry, PackageMetadata)}: content that names no
+ * version spans every live version of its anchor's nsURI - that is what makes a version
+ * bump cost nothing for mappings and profiles - while content naming one through
+ * {@code emf.fingerprint} goes onto that version alone. Placement is therefore also
+ * provenance: the fingerprint of the {@link PackageMetadata} containing an aspect is the
+ * fingerprint of the package its content was built from.
  * <p>
  * <b>Boundaries.</b> The aspect content is a <em>copy</em> of the registry object -
  * {@code AspectEntry#content} is a containment slot, and stealing the live object out
@@ -111,14 +122,18 @@ public class RegistryMetadataBridge implements EObjectRegistryListener, Metadata
 	}
 
 	/**
-	 * A new model version's tree is being built: re-contribute the current content
-	 * whose anchors live in that package. This is what keeps aspects alive across model
-	 * version bumps and late-starting model bundles.
+	 * A new model version's tree is being built: re-contribute the current content that
+	 * belongs to this version and whose anchors live in that package. This is what keeps
+	 * aspects alive across model version bumps and late-starting model bundles - including
+	 * a derived artifact that named its version before the version was deployed.
 	 */
 	@Override
 	public void onPackageRegistered(PackageMetadata packageMetadata) {
 		synchronized (lock) {
 			for (EObjectRegistryEntry entry : mirror.values()) {
+				if (!belongsTo(entry, packageMetadata)) {
+					continue;
+				}
 				for (EClass anchor : anchorResolver.anchorsOf(entry)) {
 					if (Objects.equals(nsUriOf(anchor), packageMetadata.getNsURI())) {
 						findClass(packageMetadata, anchor.getName()).ifPresent(cm -> place(entry, cm));
@@ -131,9 +146,12 @@ public class RegistryMetadataBridge implements EObjectRegistryListener, Metadata
 	@Override
 	public void onPackageUnregistered(PackageMetadata packageMetadata) {
 		synchronized (lock) {
-			// the tree dies with its aspects - just forget the placements that live in it
-			placed.values()
-					.forEach(list -> list.removeIf(aspect -> EcoreUtil.getRootContainer(aspect) == packageMetadata));
+			// the tree dies with its aspects - just forget the placements that live in it.
+			// Containment reaches from the withdrawn version down to the aspect, so ask for
+			// exactly that: the root container is the whole registry, not this version, and
+			// at this point the version is still in it.
+			placed.values().forEach(list -> list.removeIf(aspect -> EcoreUtil.isAncestor(packageMetadata, aspect)));
+			placed.values().removeIf(List::isEmpty);
 		}
 	}
 
@@ -157,12 +175,48 @@ public class RegistryMetadataBridge implements EObjectRegistryListener, Metadata
 			if (nsUri == null) {
 				continue;
 			}
-			// every live version tree of the anchor's package gets the aspect - lookups
-			// are per fingerprint, and content anchored by class name spans versions
-			for (PackageMetadata packageMetadata : metadataService.getPackageMetadataVersions(nsUri)) {
-				findClass(packageMetadata, anchor.getName()).ifPresent(cm -> place(entry, cm));
+			// every live version tree the entry belongs to gets the aspect - lookups are
+			// per fingerprint, and content anchored by class name spans versions
+			List<PackageMetadata> versions = metadataService.getPackageMetadataVersions(nsUri);
+			boolean matched = false;
+			for (PackageMetadata packageMetadata : versions) {
+				if (belongsTo(entry, packageMetadata)) {
+					matched = true;
+					findClass(packageMetadata, anchor.getName()).ifPresent(cm -> place(entry, cm));
+				}
+			}
+			if (!matched && !versions.isEmpty()) {
+				// only reachable for a pinned entry: the nsURI is live but not in the named
+				// version. Pending, not misplaced - the version may still arrive, and then
+				// onPackageRegistered places it. Worth saying out loud, because narrowing
+				// trades a silent misplacement for a silent absence.
+				logger.warning(() -> String.format(
+						"Registry entry %s names model version %s of %s, which is not among the %d live version(s) - no aspect placed",
+						entry.key(), entry.properties().get(FINGERPRINT_ATTRIBUTE), nsUri, versions.size()));
 			}
 		}
+	}
+
+	/**
+	 * Whether an entry's content belongs on a given model version's tree.
+	 * <p>
+	 * Content that says nothing about a version is version-independent - a mapping, a
+	 * profile, a service configuration - and goes onto every live version of its anchor's
+	 * nsURI. An entry that names a version through {@code emf.fingerprint} is a
+	 * <b>derived</b> artifact: it was built from one package instance and
+	 * {@link EcoreUtil#copy} keeps its non-containment references pointing into
+	 * that instance. Copied onto another version's tree it would navigate the wrong
+	 * package - failing at {@code eGet} with dynamic EMF, or quietly resolving by name and
+	 * answering from the wrong model with generated code. It therefore belongs on the
+	 * version it names and on no other (issue #81).
+	 *
+	 * @param entry           the registry entry
+	 * @param packageMetadata the candidate model version
+	 * @return {@code true} if the entry may be placed on this version
+	 */
+	private static boolean belongsTo(EObjectRegistryEntry entry, PackageMetadata packageMetadata) {
+		Object fingerprint = entry.properties().get(FINGERPRINT_ATTRIBUTE);
+		return fingerprint == null || Objects.equals(fingerprint.toString(), packageMetadata.getModelFingerprint());
 	}
 
 	private void place(EObjectRegistryEntry entry, ClassMetadata classMetadata) {

--- a/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/src/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/RegistryMetadataBridge.java
+++ b/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/src/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/RegistryMetadataBridge.java
@@ -15,6 +15,7 @@ package org.eclipse.fennec.emf.osgi.eobject.registry.metadata;
 import static org.eclipse.fennec.emf.osgi.annotation.provide.EPackage.FINGERPRINT_ATTRIBUTE;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -178,21 +179,25 @@ public class RegistryMetadataBridge implements EObjectRegistryListener, Metadata
 			// every live version tree the entry belongs to gets the aspect - lookups are
 			// per fingerprint, and content anchored by class name spans versions
 			List<PackageMetadata> versions = metadataService.getPackageMetadataVersions(nsUri);
-			boolean matched = false;
+			int placements = 0;
 			for (PackageMetadata packageMetadata : versions) {
 				if (belongsTo(entry, packageMetadata)) {
-					matched = true;
-					findClass(packageMetadata, anchor.getName()).ifPresent(cm -> place(entry, cm));
+					Optional<ClassMetadata> classMetadata = findClass(packageMetadata, anchor.getName());
+					classMetadata.ifPresent(cm -> place(entry, cm));
+					placements += classMetadata.isPresent() ? 1 : 0;
 				}
 			}
-			if (!matched && !versions.isEmpty()) {
-				// only reachable for a pinned entry: the nsURI is live but not in the named
-				// version. Pending, not misplaced - the version may still arrive, and then
-				// onPackageRegistered places it. Worth saying out loud, because narrowing
-				// trades a silent misplacement for a silent absence.
+			if (placements == 0 && !versions.isEmpty()) {
+				// The nsURI is deployed, yet the entry reached nothing: either it names a
+				// version that is not live, or the named version does not carry the anchor
+				// class. Both are pending rather than misplaced - a matching version may
+				// still arrive and onPackageRegistered places it then - but both are worth
+				// saying out loud, because narrowing trades a silent misplacement for a
+				// silent absence. A cold start with no version live at all stays quiet: that
+				// is the normal state, not a suspicion.
 				logger.warning(() -> String.format(
-						"Registry entry %s names model version %s of %s, which is not among the %d live version(s) - no aspect placed",
-						entry.key(), entry.properties().get(FINGERPRINT_ATTRIBUTE), nsUri, versions.size()));
+						"Registry entry %s: no aspect placed on any of the %d live version(s) of %s (anchor %s, emf.fingerprint=%s)",
+						entry.key(), versions.size(), nsUri, anchor.getName(), pinnedFingerprint(entry)));
 			}
 		}
 	}
@@ -215,8 +220,41 @@ public class RegistryMetadataBridge implements EObjectRegistryListener, Metadata
 	 * @return {@code true} if the entry may be placed on this version
 	 */
 	private static boolean belongsTo(EObjectRegistryEntry entry, PackageMetadata packageMetadata) {
-		Object fingerprint = entry.properties().get(FINGERPRINT_ATTRIBUTE);
-		return fingerprint == null || Objects.equals(fingerprint.toString(), packageMetadata.getModelFingerprint());
+		String fingerprint = pinnedFingerprint(entry);
+		return fingerprint == null || fingerprint.equals(packageMetadata.getModelFingerprint());
+	}
+
+	/**
+	 * The model version an entry names, or {@code null} if it names none.
+	 * <p>
+	 * A <b>blank</b> value is not a version: {@code emf.fingerprint} is optional precisely
+	 * because a provider may be unable to state it reliably, and
+	 * {@link org.eclipse.fennec.emf.osgi.annotation.provide.EPackage#fingerprint()} requires
+	 * consumers to read an absent fingerprint as unknown, never as a mismatch. Treating it
+	 * as a mismatch would silently drop the content over a property that was meant to be
+	 * optional.
+	 * <p>
+	 * Entry properties are also frequently copied wholesale from OSGi service properties or
+	 * Configurator JSON, where a single value legitimately arrives as a one-element array or
+	 * collection - unwrapped here, because comparing {@code String[].toString()} would never
+	 * match. A genuinely multi-valued property names no single version and is therefore read
+	 * as unknown as well.
+	 *
+	 * @param entry the registry entry
+	 * @return the named fingerprint, or {@code null} if the entry names no version
+	 */
+	private static String pinnedFingerprint(EObjectRegistryEntry entry) {
+		Object value = entry.properties().get(FINGERPRINT_ATTRIBUTE);
+		if (value instanceof Object[] array) {
+			value = array.length == 1 ? array[0] : null;
+		} else if (value instanceof Collection<?> collection) {
+			value = collection.size() == 1 ? collection.iterator().next() : null;
+		}
+		if (value == null) {
+			return null;
+		}
+		String fingerprint = value.toString().strip();
+		return fingerprint.isEmpty() ? null : fingerprint;
 	}
 
 	private void place(EObjectRegistryEntry entry, ClassMetadata classMetadata) {

--- a/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/DerivedContentReferenceIntegrityTest.java
+++ b/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/DerivedContentReferenceIntegrityTest.java
@@ -1,0 +1,309 @@
+/********************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Data In Motion Consulting - initial implementation
+ ********************************************************************/
+package org.eclipse.fennec.emf.osgi.eobject.registry.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.fennec.emf.osgi.annotation.provide.EPackage.FINGERPRINT_ATTRIBUTE;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EClassifier;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.ecore.EStructuralFeature;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistries;
+import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistryWriter;
+import org.eclipse.fennec.emf.osgi.metadata.MetadataServices;
+import org.eclipse.fennec.emf.osgi.metadata.MetadataWhiteboard;
+import org.eclipse.fennec.emf.osgi.model.metadata.AspectEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * <b>Why</b> derived content must not be copied across model versions (issue #81), pinned
+ * down at the level the bug actually lives on: the references inside the copy.
+ * <p>
+ * The placement tests distinguish versions by a string attribute; that proves the routing
+ * but not the reason for it. These tests assert the object identities: the copy in an
+ * {@link AspectEntry} keeps its <b>non-containment</b> references pointing at the very
+ * {@code EStructuralFeature} and {@code EClassifier} instances the artifact was derived
+ * against - which is correct exactly as long as the aspect sits on that version's tree,
+ * and wrong on any other. They are the regression guard for the copy mechanism itself: a
+ * future change to how content is snapshotted has to keep these identities intact, or the
+ * cross-version mix-up returns without any routing test noticing.
+ * <p>
+ * Also documented here, deliberately, is the <b>limit</b> of the guard: content that names
+ * no version still spans every live version, references and all. That is why the guide
+ * states carrying {@code emf.fingerprint} as an obligation for content holding model
+ * references rather than as an option.
+ */
+public class DerivedContentReferenceIntegrityTest {
+
+	private static final String NS_URI = "http://fennec.eclipse.org/test/sensors";
+	private static final String TYPE_ID = "compiled.ocl";
+	private static final String ANCHOR_NAME = "TemperatureSensor";
+	private static final String MEASURED_FEATURE = "measured";
+
+	/**
+	 * The content model, shaped like a compiled expression: it holds the feature it
+	 * resolved against, a containment list of steps, and each step holds a classifier plus
+	 * a reference to a sibling step - the three reference cases that must behave
+	 * differently under a copy.
+	 */
+	private EPackage contentPackage;
+	private EClass expressionClass;
+	private EAttribute bodyAttribute;
+	private EReference resolvedFeature;
+	private EReference steps;
+	private EClass stepClass;
+	private EReference stepClassifier;
+	private EReference stepSibling;
+
+	private MetadataWhiteboard whiteboard;
+
+	@BeforeEach
+	public void setUp() {
+		contentPackage = EcoreFactory.eINSTANCE.createEPackage();
+		contentPackage.setName("expressions");
+		contentPackage.setNsPrefix("expressions");
+		contentPackage.setNsURI("http://fennec.eclipse.org/test/expressions");
+
+		stepClass = EcoreFactory.eINSTANCE.createEClass();
+		stepClass.setName("Step");
+		stepClassifier = reference(stepClass, "classifier", EcorePackage.Literals.ECLASSIFIER, false);
+		stepSibling = reference(stepClass, "sibling", stepClass, false);
+
+		expressionClass = EcoreFactory.eINSTANCE.createEClass();
+		expressionClass.setName("CompiledExpression");
+		bodyAttribute = EcoreFactory.eINSTANCE.createEAttribute();
+		bodyAttribute.setName("body");
+		bodyAttribute.setEType(EcorePackage.Literals.ESTRING);
+		expressionClass.getEStructuralFeatures().add(bodyAttribute);
+		resolvedFeature = reference(expressionClass, "resolvedFeature", EcorePackage.Literals.ESTRUCTURAL_FEATURE,
+				false);
+		steps = reference(expressionClass, "steps", stepClass, true);
+		steps.setUpperBound(-1);
+
+		contentPackage.getEClassifiers().add(stepClass);
+		contentPackage.getEClassifiers().add(expressionClass);
+
+		whiteboard = MetadataServices.createWhiteboard();
+	}
+
+	private EReference reference(EClass owner, String name, EClassifier type, boolean containment) {
+		EReference eReference = EcoreFactory.eINSTANCE.createEReference();
+		eReference.setName(name);
+		eReference.setEType(type);
+		eReference.setContainment(containment);
+		owner.getEStructuralFeatures().add(eReference);
+		return eReference;
+	}
+
+	/** A domain model version; every version carries the anchor and a measured feature. */
+	private EPackage domainVersion(String... extraFeatures) {
+		EPackage ePackage = EcoreFactory.eINSTANCE.createEPackage();
+		ePackage.setName("sensors");
+		ePackage.setNsPrefix("sensors");
+		ePackage.setNsURI(NS_URI);
+		EClass anchor = EcoreFactory.eINSTANCE.createEClass();
+		anchor.setName(ANCHOR_NAME);
+		EAttribute measured = EcoreFactory.eINSTANCE.createEAttribute();
+		measured.setName(MEASURED_FEATURE);
+		measured.setEType(EcorePackage.Literals.EDOUBLE);
+		anchor.getEStructuralFeatures().add(measured);
+		for (String featureName : extraFeatures) {
+			EAttribute attribute = EcoreFactory.eINSTANCE.createEAttribute();
+			attribute.setName(featureName);
+			attribute.setEType(EcorePackage.Literals.ESTRING);
+			anchor.getEStructuralFeatures().add(attribute);
+		}
+		ePackage.getEClassifiers().add(anchor);
+		return ePackage;
+	}
+
+	private EClass anchorOf(EPackage domainVersion) {
+		return (EClass) domainVersion.getEClassifier(ANCHOR_NAME);
+	}
+
+	private EStructuralFeature measuredOf(EPackage domainVersion) {
+		return anchorOf(domainVersion).getEStructuralFeature(MEASURED_FEATURE);
+	}
+
+	/**
+	 * An artifact "compiled" against one model version: it resolves the measured feature
+	 * and two steps, the second referring back to the first.
+	 */
+	private EObject compiledAgainst(EPackage domainVersion, String body) {
+		EObject expression = EcoreUtil.create(expressionClass);
+		expression.eSet(bodyAttribute, body);
+		expression.eSet(resolvedFeature, measuredOf(domainVersion));
+
+		EObject first = EcoreUtil.create(stepClass);
+		first.eSet(stepClassifier, anchorOf(domainVersion));
+		EObject second = EcoreUtil.create(stepClass);
+		second.eSet(stepClassifier, anchorOf(domainVersion));
+		second.eSet(stepSibling, first);
+		@SuppressWarnings("unchecked")
+		List<EObject> stepList = (List<EObject>) expression.eGet(steps);
+		stepList.add(first);
+		stepList.add(second);
+		return expression;
+	}
+
+	private EObjectRegistryWriter registryWithBridge(EPackage resolveAnchorAgainst) {
+		EObjectRegistryWriter writer = EObjectRegistries.createRegistry("expressions");
+		RegistryMetadataBridge bridge = new RegistryMetadataBridge(whiteboard, TYPE_ID,
+				entry -> List.of(anchorOf(resolveAnchorAgainst)));
+		whiteboard.addMetadataHandler(bridge);
+		writer.getRegistry().addListener(bridge);
+		return writer;
+	}
+
+	private EObject aspectContent(EPackage domainVersion) {
+		return whiteboard.getClassAspect(anchorOf(domainVersion), TYPE_ID).orElseThrow().getContent();
+	}
+
+	/**
+	 * The core identity claim: the snapshot on v1's tree navigates <b>v1's</b> feature
+	 * instance, not an equally named one from another version. Two live versions with the
+	 * same feature names is exactly the constellation in which name equality would hide a
+	 * wrong answer.
+	 */
+	@Test
+	public void testSnapshotOnItsVersionReferencesThatVersionsFeatureInstance() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr", compiledAgainst(v1, "v1-body"), Map.of(FINGERPRINT_ATTRIBUTE, fingerprintV1));
+
+		EObject snapshot = aspectContent(v1);
+		assertThat(snapshot.eGet(resolvedFeature)).as("the feature instance of its own version")
+				.isSameAs(measuredOf(v1));
+		assertThat(snapshot.eGet(resolvedFeature)).isNotSameAs(measuredOf(v2));
+		// name equality across versions is real - which is why identity is what matters
+		assertThat(measuredOf(v1).getName()).isEqualTo(measuredOf(v2).getName());
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).as("no snapshot on the foreign tree").isEmpty();
+	}
+
+	/**
+	 * References out of a <b>contained child</b> of the content must survive the copy the
+	 * same way - the copy is deep, and a step that resolved v1's anchor still points at
+	 * v1's anchor.
+	 */
+	@Test
+	public void testNestedContainmentKeepsItsModelReferences() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr", compiledAgainst(v1, "v1-body"), Map.of(FINGERPRINT_ATTRIBUTE, fingerprintV1));
+
+		EObject snapshot = aspectContent(v1);
+		@SuppressWarnings("unchecked")
+		List<EObject> copiedSteps = (List<EObject>) snapshot.eGet(steps);
+		assertThat(copiedSteps).hasSize(2);
+		assertThat(copiedSteps.get(0).eGet(stepClassifier)).isSameAs(anchorOf(v1));
+		assertThat(copiedSteps.get(1).eGet(stepClassifier)).isSameAs(anchorOf(v1));
+		assertThat(copiedSteps.get(0).eGet(stepClassifier)).isNotSameAs(anchorOf(v2));
+	}
+
+	/**
+	 * The complementary half of the copy contract: a reference whose target lies
+	 * <b>inside</b> the copied tree is redirected to the copy, so the snapshot is
+	 * internally consistent and never reaches back into the live registry object. Together
+	 * with the two tests above this is the full rule - intra-tree references move, model
+	 * references stay.
+	 */
+	@Test
+	public void testIntraContentReferencesAreRedirectedToTheCopy() {
+		EPackage v1 = domainVersion();
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		EObject live = compiledAgainst(v1, "v1-body");
+		writer.put("compiler", "expr", live, Map.of(FINGERPRINT_ATTRIBUTE, fingerprintV1));
+
+		EObject snapshot = aspectContent(v1);
+		@SuppressWarnings("unchecked")
+		List<EObject> copiedSteps = (List<EObject>) snapshot.eGet(steps);
+		@SuppressWarnings("unchecked")
+		List<EObject> liveSteps = (List<EObject>) live.eGet(steps);
+
+		assertThat(snapshot).isNotSameAs(live);
+		assertThat(copiedSteps.get(1).eGet(stepSibling)).as("redirected to the copied sibling")
+				.isSameAs(copiedSteps.get(0));
+		assertThat(copiedSteps.get(1).eGet(stepSibling)).isNotSameAs(liveSteps.get(0));
+		// and the live object was not stolen into the containment slot
+		assertThat(live.eContainer()).isNull();
+	}
+
+	/**
+	 * The documented <b>limit</b>: content that names no version keeps spanning every live
+	 * version - and a copy sitting on v2's tree then still references v1's feature. Nothing
+	 * detects that, which is precisely why
+	 * {@code docs/eobject-registry-guide.md} makes {@code emf.fingerprint} mandatory for
+	 * content holding model references. This test exists so the limitation is visible and
+	 * cannot be mistaken for something the guard already handles.
+	 */
+	@Test
+	public void testUnpinnedContentSpansVersionsAndKeepsItsOriginReferences() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		whiteboard.registerPackage(v1);
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("files", "expr", compiledAgainst(v1, "unpinned"), null);
+
+		assertThat(aspectContent(v1).eGet(resolvedFeature)).isSameAs(measuredOf(v1));
+		assertThat(aspectContent(v2).eGet(resolvedFeature))
+				.as("on the foreign tree, still pointing at the origin version - the reason for the MUST rule")
+				.isSameAs(measuredOf(v1));
+	}
+
+	/**
+	 * Two versions, one derived artifact each: both trees answer, and each answer navigates
+	 * its own version's features. This is the constellation the whole issue is about, at
+	 * reference level.
+	 */
+	@Test
+	public void testTwoDerivedArtifactsEachNavigateTheirOwnVersion() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		String fingerprintV2 = whiteboard.registerPackage(v2).orElseThrow().getModelFingerprint();
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr-v1", compiledAgainst(v1, "v1-body"),
+				Map.of(FINGERPRINT_ATTRIBUTE, fingerprintV1));
+		writer.put("compiler", "expr-v2", compiledAgainst(v2, "v2-body"),
+				Map.of(FINGERPRINT_ATTRIBUTE, fingerprintV2));
+
+		assertThat(aspectContent(v1).eGet(bodyAttribute)).isEqualTo("v1-body");
+		assertThat(aspectContent(v1).eGet(resolvedFeature)).isSameAs(measuredOf(v1));
+		assertThat(aspectContent(v2).eGet(bodyAttribute)).isEqualTo("v2-body");
+		assertThat(aspectContent(v2).eGet(resolvedFeature)).isSameAs(measuredOf(v2));
+	}
+}

--- a/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/FingerprintScopedPlacementTest.java
+++ b/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/FingerprintScopedPlacementTest.java
@@ -15,8 +15,13 @@ package org.eclipse.fennec.emf.osgi.eobject.registry.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.fennec.emf.osgi.annotation.provide.EPackage.FINGERPRINT_ATTRIBUTE;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
@@ -33,6 +38,7 @@ import org.eclipse.fennec.emf.osgi.metadata.MetadataWhiteboard;
 import org.eclipse.fennec.emf.osgi.model.metadata.AspectEntry;
 import org.eclipse.fennec.emf.osgi.model.metadata.ClassMetadata;
 import org.eclipse.fennec.emf.osgi.model.metadata.PackageMetadata;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -68,6 +74,50 @@ public class FingerprintScopedPlacementTest {
 
 	private MetadataWhiteboard whiteboard;
 	private AspectAnchorResolver anchorResolver;
+
+	/** Whether narrowing stayed silent or said so is part of the contract - so capture it. */
+	private final List<String> warnings = new CopyOnWriteArrayList<>();
+	private Logger bridgeLogger;
+	private Handler logHandler;
+
+	@BeforeEach
+	public void captureBridgeWarnings() {
+		bridgeLogger = Logger.getLogger(RegistryMetadataBridge.class.getName());
+		logHandler = new Handler() {
+
+			@Override
+			public void publish(LogRecord record) {
+				warnings.add(record.getMessage());
+			}
+
+			@Override
+			public void flush() {
+				// nothing buffered
+			}
+
+			@Override
+			public void close() {
+				// nothing to release
+			}
+		};
+		bridgeLogger.addHandler(logHandler);
+	}
+
+	@AfterEach
+	public void releaseLogHandler() {
+		bridgeLogger.removeHandler(logHandler);
+	}
+
+	/** The warnings about content that reached no tree, ignoring last-write-wins notices. */
+	private List<String> unplacedWarnings() {
+		List<String> matching = new ArrayList<>();
+		for (String warning : warnings) {
+			if (warning != null && warning.contains("no aspect placed")) {
+				matching.add(warning);
+			}
+		}
+		return matching;
+	}
 
 	@BeforeEach
 	public void setUp() {
@@ -343,5 +393,274 @@ public class FingerprintScopedPlacementTest {
 		writer.remove("compiler", "expr-v1");
 
 		assertThat(deadAnchor.getAspects()).as("the withdrawn tree is nobody's business anymore").hasSize(1);
+	}
+
+	// ---------------------------------------------------------------- cardinalities
+
+	/** The degenerate case the guard must not break: one live version, pinned to it. */
+	@Test
+	public void testPinnedContentWithASingleLiveVersion() {
+		EPackage only = domainVersion();
+		String fingerprint = whiteboard.registerPackage(only).orElseThrow().getModelFingerprint();
+
+		EObjectRegistryWriter writer = registryWithBridge(only);
+		writer.put("compiler", "expr", expression("only-body"), pinnedTo(fingerprint));
+
+		assertThat(whiteboard.getPackageMetadataVersions(NS_URI)).hasSize(1);
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(only), TYPE_ID).orElseThrow())).isEqualTo("only-body");
+		assertThat(unplacedWarnings()).isEmpty();
+	}
+
+	/**
+	 * No live version at all - a freshly started gateway whose content sources are up
+	 * before any model bundle. Pending is the normal state here, so it must stay
+	 * <em>silent</em>: a warning per entry on every cold start would be noise, and the
+	 * replay places the content the moment the model arrives.
+	 */
+	@Test
+	public void testPinnedContentWithNoLiveVersionIsSilentlyPending() {
+		EPackage v1 = domainVersion();
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr", expression("v1-body"), pinnedTo(FingerprintHelper.fingerprint(v1)));
+
+		assertThat(whiteboard.getPackageMetadataVersions(NS_URI)).isEmpty();
+		assertThat(unplacedWarnings()).as("nothing is wrong yet - no model is deployed").isEmpty();
+
+		whiteboard.registerPackage(v1);
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("v1-body");
+	}
+
+	/**
+	 * Five diverging versions of one nsURI: nothing in the placement path is tuned to
+	 * "two" or "three". Every version answers with its own artifact, and no tree carries
+	 * more than the one aspect that belongs to it.
+	 */
+	@Test
+	public void testFiveVersionsEachAnswerWithTheirOwnDerivedContent() {
+		List<EPackage> versions = new ArrayList<>();
+		for (int i = 1; i <= 5; i++) {
+			String[] extraFeatures = new String[i];
+			for (int j = 0; j < i; j++) {
+				extraFeatures[j] = "v" + i + "feature" + j;
+			}
+			versions.add(domainVersion(extraFeatures));
+		}
+		List<String> fingerprints = new ArrayList<>();
+		for (EPackage version : versions) {
+			fingerprints.add(whiteboard.registerPackage(version).orElseThrow().getModelFingerprint());
+		}
+		assertThat(fingerprints).doesNotHaveDuplicates();
+		assertThat(whiteboard.getPackageMetadataVersions(NS_URI)).hasSize(5);
+
+		EObjectRegistryWriter writer = registryWithBridge(versions.get(0));
+		for (int i = 0; i < versions.size(); i++) {
+			writer.put("compiler", "expr-" + i, expression("body-" + i), pinnedTo(fingerprints.get(i)));
+		}
+
+		for (int i = 0; i < versions.size(); i++) {
+			EPackage version = versions.get(i);
+			assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(version), TYPE_ID).orElseThrow()))
+					.isEqualTo("body-" + i);
+			assertThat(anchorMetadata(whiteboard.getPackageMetadata(version).orElseThrow()).getAspects()).hasSize(1);
+		}
+		assertThat(unplacedWarnings()).isEmpty();
+	}
+
+	// ------------------------------------------------------- malformed property values
+
+	/**
+	 * An <b>empty</b> fingerprint means "the provider cannot state it reliably" and must be
+	 * treated as unknown, <em>never</em> as a mismatch - the contract is spelled out on
+	 * {@code EPackage#fingerprint()} in the api bundle. Dropping such content would be the
+	 * worst of both worlds: a silent loss caused by a property that was meant to be
+	 * optional.
+	 */
+	@Test
+	public void testBlankFingerprintIsTreatedAsUnknownNotAsMismatch() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		whiteboard.registerPackage(v1);
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr", expression("stated-nothing"), pinnedTo(""));
+
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).as("empty is unknown, not a mismatch")
+				.isPresent();
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).isPresent();
+
+		// whitespace is no more of a statement than the empty string
+		writer.put("compiler", "expr", expression("still-nothing"), pinnedTo("   "));
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).isEqualTo("still-nothing");
+	}
+
+	/**
+	 * Entry properties are frequently copied wholesale from OSGi service properties or
+	 * Configurator JSON - where a single value legitimately arrives as a one-element array.
+	 * Comparing {@code String[].toString()} against a fingerprint would never match and
+	 * would drop the content.
+	 */
+	@Test
+	public void testFingerprintGivenAsSingleElementArrayIsHonoured() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr", expression("v1-body"),
+				Map.of(FINGERPRINT_ATTRIBUTE, new String[] { fingerprintV1 }));
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("v1-body");
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).as("still pinned").isEmpty();
+	}
+
+	/**
+	 * A multi-valued fingerprint states no single version. It is a producer bug, and the
+	 * safe reading is the documented one - unknown rather than a mismatch - so the content
+	 * behaves like version-independent content instead of vanishing.
+	 */
+	@Test
+	public void testMultiValuedFingerprintIsTreatedAsUnknown() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		String fingerprintV2 = whiteboard.registerPackage(v2).orElseThrow().getModelFingerprint();
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr", expression("ambiguous"),
+				Map.of(FINGERPRINT_ATTRIBUTE, List.of(fingerprintV1, fingerprintV2)));
+
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).isPresent();
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).isPresent();
+	}
+
+	// ------------------------------------------------------------ state transitions
+
+	/**
+	 * A source learns the version later - the atlas first hands out a mapping, then the
+	 * fingerprint it was derived against. The update must <b>shrink</b> the placement from
+	 * every version to the named one.
+	 */
+	@Test
+	public void testEntryBecomingPinnedShrinksToItsVersion() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		EPackage v3 = domainVersion("accuracy", "precision");
+		String fingerprintV2 = whiteboard.registerPackage(v2).orElseThrow().getModelFingerprint();
+		whiteboard.registerPackage(v1);
+		whiteboard.registerPackage(v3);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("atlas", "expr", expression("unpinned"), null);
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).isPresent();
+		assertThat(whiteboard.getClassAspect(anchorOf(v3), TYPE_ID)).isPresent();
+
+		writer.put("atlas", "expr", expression("now-pinned"), pinnedTo(fingerprintV2));
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).isEqualTo("now-pinned");
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).as("dropped from the other versions").isEmpty();
+		assertThat(whiteboard.getClassAspect(anchorOf(v3), TYPE_ID)).isEmpty();
+	}
+
+	/** And the reverse: dropping the pin re-opens the entry to every live version. */
+	@Test
+	public void testEntryLosingItsPinSpansAllVersionsAgain() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("atlas", "expr", expression("pinned"), pinnedTo(fingerprintV1));
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).isEmpty();
+
+		writer.put("atlas", "expr", expression("unpinned"), null);
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("unpinned");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).isEqualTo("unpinned");
+	}
+
+	// ----------------------------------------------------------------- anchor edges
+
+	/**
+	 * The named version exists but does not carry the anchor class - it was renamed or
+	 * dropped in that version. Nothing can be placed, and unlike the cold-start case this
+	 * <em>is</em> worth saying out loud: an entry names a deployed version and still reaches
+	 * nothing.
+	 */
+	@Test
+	public void testAnchorMissingInTheNamedVersionPlacesNothingAndWarns() {
+		EPackage renamed = domainVersion("accuracy");
+		anchorOf(renamed).setName("RenamedSensor");
+		String fingerprint = whiteboard.registerPackage(renamed).orElseThrow().getModelFingerprint();
+		EPackage v1 = domainVersion();
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr", expression("orphan"), pinnedTo(fingerprint));
+
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).isEmpty();
+		assertThat(unplacedWarnings()).as("a named, deployed version that reaches nothing is reported").hasSize(1);
+		assertThat(unplacedWarnings().get(0)).contains("expr");
+	}
+
+	/** A pinned entry with several anchors places all of them - on its version only. */
+	@Test
+	public void testPinnedMultiAnchorContentPlacesEveryAnchorOnItsVersionOnly() {
+		EPackage v1 = domainVersion();
+		EClass secondAnchor = EcoreFactory.eINSTANCE.createEClass();
+		secondAnchor.setName("HumiditySensor");
+		v1.getEClassifiers().add(secondAnchor);
+		EPackage v2 = EcoreUtil.copy(v1);
+		EAttribute extra = EcoreFactory.eINSTANCE.createEAttribute();
+		extra.setName("accuracy");
+		extra.setEType(EcorePackage.Literals.ESTRING);
+		((EClass) v2.getEClassifier(ANCHOR_NAME)).getEStructuralFeatures().add(extra);
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = EObjectRegistries.createRegistry("expressions");
+		RegistryMetadataBridge bridge = new RegistryMetadataBridge(whiteboard, TYPE_ID,
+				entry -> List.of(anchorOf(v1), secondAnchor));
+		whiteboard.addMetadataHandler(bridge);
+		writer.getRegistry().addListener(bridge);
+
+		writer.put("compiler", "expr", expression("v1-body"), pinnedTo(fingerprintV1));
+
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).isPresent();
+		assertThat(whiteboard.getClassAspect(secondAnchor, TYPE_ID)).isPresent();
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).as("neither anchor on the foreign version")
+				.isEmpty();
+		assertThat(whiteboard.getClassAspect((EClass) v2.getEClassifier("HumiditySensor"), TYPE_ID)).isEmpty();
+	}
+
+	// ---------------------------------------------------------------------- legacy
+
+	/**
+	 * A legacy model advertises no {@code emf.fingerprint} - generated code from before the
+	 * scheme existed, or a dynamically loaded ecore. Metadata identity does not depend on
+	 * that: the service <b>computes</b> the fingerprint for every version it registers
+	 * ({@code MetadataServiceImpl} treats a supplied value as context, never as truth). A
+	 * producer can therefore pin derived content against a legacy model just as well - it
+	 * reads the computed value instead of a bundle property.
+	 */
+	@Test
+	public void testLegacyModelWithoutAdvertisedFingerprintCanStillBePinned() {
+		EPackage legacy = domainVersion();
+		EPackage other = domainVersion("accuracy");
+		PackageMetadata legacyMetadata = whiteboard.registerPackage(legacy).orElseThrow();
+		whiteboard.registerPackage(other);
+
+		assertThat(legacyMetadata.getModelFingerprint()).as("identity is computed, not advertised").isNotBlank()
+				.startsWith(FingerprintHelper.currentScheme());
+		assertThat(legacyMetadata.getModelFingerprint()).isEqualTo(FingerprintHelper.fingerprint(legacy));
+
+		EObjectRegistryWriter writer = registryWithBridge(legacy);
+		writer.put("compiler", "expr", expression("legacy-body"),
+				pinnedTo(legacyMetadata.getModelFingerprint()));
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(legacy), TYPE_ID).orElseThrow()))
+				.isEqualTo("legacy-body");
+		assertThat(whiteboard.getClassAspect(anchorOf(other), TYPE_ID)).isEmpty();
 	}
 }

--- a/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/FingerprintScopedPlacementTest.java
+++ b/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/FingerprintScopedPlacementTest.java
@@ -1,0 +1,347 @@
+/********************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Data In Motion Consulting - initial implementation
+ ********************************************************************/
+package org.eclipse.fennec.emf.osgi.eobject.registry.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.fennec.emf.osgi.annotation.provide.EPackage.FINGERPRINT_ATTRIBUTE;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EcoreFactory;
+import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistries;
+import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistryWriter;
+import org.eclipse.fennec.emf.osgi.fingerprint.util.FingerprintHelper;
+import org.eclipse.fennec.emf.osgi.metadata.MetadataServices;
+import org.eclipse.fennec.emf.osgi.metadata.MetadataWhiteboard;
+import org.eclipse.fennec.emf.osgi.model.metadata.AspectEntry;
+import org.eclipse.fennec.emf.osgi.model.metadata.ClassMetadata;
+import org.eclipse.fennec.emf.osgi.model.metadata.PackageMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Placement across several live versions of one nsURI (issue #81).
+ * <p>
+ * The bridge copies entry content with {@code EcoreUtil.copy}, which keeps
+ * non-containment references pointing at the <em>originals</em>. For version-independent
+ * content - a mapping, a profile - that is harmless and spanning every live version is
+ * the feature. For a <b>derived</b> artifact - compiled OCL holding the
+ * {@code EStructuralFeature} instances it resolved against - a copy on a foreign version's
+ * tree navigates the wrong package: with dynamic EMF it fails at {@code eGet}, with
+ * generated code it may resolve by name and quietly answer from the wrong model. That is
+ * the failure fingerprint identity exists to prevent.
+ * <p>
+ * The contract these tests pin down: <b>an entry that names a version through
+ * {@code emf.fingerprint} belongs on that version and no other; an entry that names none
+ * is version-independent and goes onto every live version of its anchor's nsURI.</b> The
+ * placement is therefore also the provenance - the fingerprint of the
+ * {@link PackageMetadata} containing an aspect is the fingerprint of the package its
+ * content was built from, which is exactly what the unguarded copy made untrue.
+ */
+public class FingerprintScopedPlacementTest {
+
+	private static final String NS_URI = "http://fennec.eclipse.org/test/sensors";
+	private static final String TYPE_ID = "compiled.ocl";
+	private static final String ANCHOR_NAME = "TemperatureSensor";
+
+	/** The content model: what a derived artifact looks like, reduced to a label. */
+	private EPackage contentPackage;
+	private EClass expressionClass;
+	private EAttribute bodyAttribute;
+
+	private MetadataWhiteboard whiteboard;
+	private AspectAnchorResolver anchorResolver;
+
+	@BeforeEach
+	public void setUp() {
+		contentPackage = EcoreFactory.eINSTANCE.createEPackage();
+		contentPackage.setName("expressions");
+		contentPackage.setNsPrefix("expressions");
+		contentPackage.setNsURI("http://fennec.eclipse.org/test/expressions");
+		expressionClass = EcoreFactory.eINSTANCE.createEClass();
+		expressionClass.setName("CompiledExpression");
+		bodyAttribute = EcoreFactory.eINSTANCE.createEAttribute();
+		bodyAttribute.setName("body");
+		bodyAttribute.setEType(EcorePackage.Literals.ESTRING);
+		expressionClass.getEStructuralFeatures().add(bodyAttribute);
+		contentPackage.getEClassifiers().add(expressionClass);
+
+		whiteboard = MetadataServices.createWhiteboard();
+	}
+
+	/**
+	 * A domain model version. Every version carries the anchor class under the same name -
+	 * that is what lets content span versions - and differs structurally, so the
+	 * fingerprints differ.
+	 *
+	 * @param extraFeatures feature names distinguishing this version from the others
+	 * @return the package, not yet registered
+	 */
+	private EPackage domainVersion(String... extraFeatures) {
+		EPackage ePackage = EcoreFactory.eINSTANCE.createEPackage();
+		ePackage.setName("sensors");
+		ePackage.setNsPrefix("sensors");
+		ePackage.setNsURI(NS_URI);
+		EClass anchor = EcoreFactory.eINSTANCE.createEClass();
+		anchor.setName(ANCHOR_NAME);
+		for (String featureName : extraFeatures) {
+			EAttribute attribute = EcoreFactory.eINSTANCE.createEAttribute();
+			attribute.setName(featureName);
+			attribute.setEType(EcorePackage.Literals.ESTRING);
+			anchor.getEStructuralFeatures().add(attribute);
+		}
+		ePackage.getEClassifiers().add(anchor);
+		return ePackage;
+	}
+
+	private EClass anchorOf(EPackage domainVersion) {
+		return (EClass) domainVersion.getEClassifier(ANCHOR_NAME);
+	}
+
+	private EObject expression(String body) {
+		EObject expression = EcoreUtil.create(expressionClass);
+		expression.eSet(bodyAttribute, body);
+		return expression;
+	}
+
+	private String bodyOf(AspectEntry aspect) {
+		return (String) aspect.getContent().eGet(bodyAttribute);
+	}
+
+	/**
+	 * Registry plus bridge, wired the way the OSGi components do. The anchor is resolved
+	 * against the version handed in here; placement itself is by class name, so content
+	 * resolved against one version's EClass can still land on another version's tree -
+	 * which is the whole point of the guard under test.
+	 */
+	private EObjectRegistryWriter registryWithBridge(EPackage resolveAnchorAgainst) {
+		EObjectRegistryWriter writer = EObjectRegistries.createRegistry("expressions");
+		anchorResolver = entry -> List.of(anchorOf(resolveAnchorAgainst));
+		RegistryMetadataBridge bridge = new RegistryMetadataBridge(whiteboard, TYPE_ID, anchorResolver);
+		whiteboard.addMetadataHandler(bridge);
+		writer.getRegistry().addListener(bridge);
+		return writer;
+	}
+
+	private Map<String, Object> pinnedTo(String fingerprint) {
+		return Map.of(FINGERPRINT_ATTRIBUTE, fingerprint);
+	}
+
+	private ClassMetadata anchorMetadata(PackageMetadata packageMetadata) {
+		return packageMetadata.getClasses().stream().filter(cm -> ANCHOR_NAME.equals(cm.getName())).findFirst()
+				.orElseThrow();
+	}
+
+	/**
+	 * The reported bug, minimal: content pinned to v1 must not be copied onto v2's tree
+	 * when the version bump arrives. Both versions stay live, only v1 answers.
+	 */
+	@Test
+	public void testPinnedContentStaysOnItsVersionWhenAnotherRegisters() {
+		EPackage v1 = domainVersion();
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr-1", expression("v1-body"), pinnedTo(fingerprintV1));
+
+		EPackage v2 = domainVersion("accuracy");
+		whiteboard.registerPackage(v2);
+
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).as("its own version answers").isPresent();
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).as("the foreign version must not").isEmpty();
+	}
+
+	/**
+	 * The same, with the entry arriving first: the guard sits in the handler replay path
+	 * too, and must narrow it without breaking it. v2 is live from the start, so a missing
+	 * guard would place on v2 and the later v1 registration would look correct anyway -
+	 * this is the test that fails for the right reason.
+	 */
+	@Test
+	public void testPinnedContentReachesItsVersionRegisteringLater() {
+		EPackage v2 = domainVersion("accuracy");
+		whiteboard.registerPackage(v2);
+		EPackage v1 = domainVersion();
+		// the fingerprint is stated before the model is there - the derived artifact was
+		// built elsewhere (a compiler, a model atlas) and names the version it targets
+		String fingerprintV1 = FingerprintHelper.fingerprint(v1);
+
+		EObjectRegistryWriter writer = registryWithBridge(v2);
+		writer.put("compiler", "expr-1", expression("v1-body"), pinnedTo(fingerprintV1));
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).as("not this version's content").isEmpty();
+
+		whiteboard.registerPackage(v1);
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("v1-body");
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).as("still not v2's").isEmpty();
+	}
+
+	/**
+	 * Three live versions of one nsURI, three fingerprints, one derived entry per version:
+	 * every version answers with its own content and nothing else. Without the guard all
+	 * three entries land on all three trees, one aspect per anchor and type id wins, and
+	 * two of the three versions answer with a foreign artifact.
+	 */
+	@Test
+	public void testThreeVersionsEachAnswerWithTheirOwnDerivedContent() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		EPackage v3 = domainVersion("accuracy", "precision");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		String fingerprintV2 = whiteboard.registerPackage(v2).orElseThrow().getModelFingerprint();
+		String fingerprintV3 = whiteboard.registerPackage(v3).orElseThrow().getModelFingerprint();
+		assertThat(List.of(fingerprintV1, fingerprintV2, fingerprintV3)).doesNotHaveDuplicates();
+		assertThat(whiteboard.getPackageMetadataVersions(NS_URI)).hasSize(3);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr-v1", expression("v1-body"), pinnedTo(fingerprintV1));
+		writer.put("compiler", "expr-v2", expression("v2-body"), pinnedTo(fingerprintV2));
+		writer.put("compiler", "expr-v3", expression("v3-body"), pinnedTo(fingerprintV3));
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("v1-body");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).isEqualTo("v2-body");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v3), TYPE_ID).orElseThrow())).isEqualTo("v3-body");
+		// one aspect per tree, not three placements fighting over one slot
+		assertThat(anchorMetadata(whiteboard.getPackageMetadata(v2).orElseThrow()).getAspects()).hasSize(1);
+	}
+
+	/**
+	 * The same three versions in the other order: the entries exist before any model does,
+	 * and each registration picks up exactly the one entry that names it. This is the
+	 * start-ordering guarantee of the registry (no DS ordering, cf. use case 2) applied per
+	 * version.
+	 */
+	@Test
+	public void testThreeVersionsRegisteringAfterTheContentEachPickUpTheirOwn() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		EPackage v3 = domainVersion("accuracy", "precision");
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr-v1", expression("v1-body"), pinnedTo(FingerprintHelper.fingerprint(v1)));
+		writer.put("compiler", "expr-v2", expression("v2-body"), pinnedTo(FingerprintHelper.fingerprint(v2)));
+		writer.put("compiler", "expr-v3", expression("v3-body"), pinnedTo(FingerprintHelper.fingerprint(v3)));
+
+		whiteboard.registerPackage(v3);
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v3), TYPE_ID).orElseThrow())).isEqualTo("v3-body");
+
+		whiteboard.registerPackage(v1);
+		whiteboard.registerPackage(v2);
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("v1-body");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).isEqualTo("v2-body");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v3), TYPE_ID).orElseThrow())).isEqualTo("v3-body");
+	}
+
+	/**
+	 * The compatibility half of the contract: an entry that names no version keeps spanning
+	 * every live version, across all three trees. This is what makes a version bump cost
+	 * nothing for mappings and profiles, and it must stay untouched by the guard.
+	 */
+	@Test
+	public void testVersionIndependentContentStillSpansAllThreeVersions() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		EPackage v3 = domainVersion("accuracy", "precision");
+		whiteboard.registerPackage(v1);
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		// properties without a fingerprint: provenance is stated, the version is not
+		writer.put("files", "mapping-1", expression("any-version"), Map.of("emf.nsURI", NS_URI));
+
+		whiteboard.registerPackage(v3);
+
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("any-version");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).isEqualTo("any-version");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v3), TYPE_ID).orElseThrow())).isEqualTo("any-version");
+	}
+
+	/**
+	 * An entry pinned to a version nobody provides lands nowhere - not on a plausible
+	 * neighbour. Narrowing turns a silent misplacement into a silent absence, which is the
+	 * safe direction but still needs to be a deliberate, logged decision rather than an
+	 * accident.
+	 */
+	@Test
+	public void testPinnedContentForAnUnknownVersionLandsNowhere() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		whiteboard.registerPackage(v1);
+		whiteboard.registerPackage(v2);
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr-stale", expression("built-against-a-gone-version"),
+				pinnedTo("fp1:0000000000000000000000000000000000000000000000000000000000000000"));
+
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).isEmpty();
+		assertThat(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID)).isEmpty();
+		// the registry keeps it: the model may still arrive, and the replay will place it
+		assertThat(writer.getRegistry().get("expr-stale")).isPresent();
+	}
+
+	/**
+	 * Cross-version updates and removals stay scoped. A pinned entry is replaced and
+	 * removed without ever touching the other versions' aspects - the bookkeeping is per
+	 * placement, not per nsURI.
+	 */
+	@Test
+	public void testUpdateAndRemovalOfOnePinnedEntryLeaveTheOtherVersionsAlone() {
+		EPackage v1 = domainVersion();
+		EPackage v2 = domainVersion("accuracy");
+		String fingerprintV1 = whiteboard.registerPackage(v1).orElseThrow().getModelFingerprint();
+		String fingerprintV2 = whiteboard.registerPackage(v2).orElseThrow().getModelFingerprint();
+
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr-v1", expression("v1-body"), pinnedTo(fingerprintV1));
+		writer.put("compiler", "expr-v2", expression("v2-body"), pinnedTo(fingerprintV2));
+
+		writer.put("compiler", "expr-v1", expression("v1-recompiled"), pinnedTo(fingerprintV1));
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID).orElseThrow())).isEqualTo("v1-recompiled");
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).isEqualTo("v2-body");
+
+		writer.remove("compiler", "expr-v1");
+		assertThat(whiteboard.getClassAspect(anchorOf(v1), TYPE_ID)).isEmpty();
+		assertThat(bodyOf(whiteboard.getClassAspect(anchorOf(v2), TYPE_ID).orElseThrow())).as("untouched")
+				.isEqualTo("v2-body");
+	}
+
+	/**
+	 * A withdrawn version's placements are forgotten, as
+	 * {@code onPackageUnregistered} documents: the tree dies with its aspects. Observable
+	 * because a later removal of the entry must then no longer reach into the dead tree -
+	 * if the bridge still tracked those aspects it would keep whole content copies alive
+	 * for every version that ever came and went.
+	 */
+	@Test
+	public void testWithdrawnVersionPlacementsAreForgotten() {
+		EPackage v1 = domainVersion();
+		PackageMetadata metadataV1 = whiteboard.registerPackage(v1).orElseThrow();
+		String fingerprintV1 = metadataV1.getModelFingerprint();
+		EObjectRegistryWriter writer = registryWithBridge(v1);
+		writer.put("compiler", "expr-v1", expression("v1-body"), pinnedTo(fingerprintV1));
+		ClassMetadata deadAnchor = anchorMetadata(metadataV1);
+		assertThat(deadAnchor.getAspects()).hasSize(1);
+
+		whiteboard.unregisterPackage(v1);
+		writer.remove("compiler", "expr-v1");
+
+		assertThat(deadAnchor.getAspects()).as("the withdrawn tree is nobody's business anymore").hasSize(1);
+	}
+}

--- a/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/InitialProviderBridgeUseCasesTest.java
+++ b/org.eclipse.fennec.emf.osgi.eobject.registry.metadata/test/org/eclipse/fennec/emf/osgi/eobject/registry/metadata/InitialProviderBridgeUseCasesTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.fennec.emf.osgi.eobject.registry.metadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.fennec.emf.osgi.annotation.provide.EPackage.FINGERPRINT_ATTRIBUTE;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -35,6 +36,7 @@ import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistries;
 import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistryEntry;
 import org.eclipse.fennec.emf.osgi.eobject.registry.EObjectRegistryWriter;
 import org.eclipse.fennec.emf.osgi.eobject.registry.FileEObjectProvider;
+import org.eclipse.fennec.emf.osgi.fingerprint.util.FingerprintHelper;
 import org.eclipse.fennec.emf.osgi.metadata.MetadataServices;
 import org.eclipse.fennec.emf.osgi.metadata.MetadataWhiteboard;
 import org.eclipse.fennec.emf.osgi.model.metadata.AspectEntry;
@@ -220,6 +222,63 @@ public class InitialProviderBridgeUseCasesTest {
 		assertThat(whiteboard.getClassAspect(temperatureSensor, TYPE_ID)).as("v1 keeps its aspect").isPresent();
 		AspectEntry v2Aspect = whiteboard.getClassAspect(temperatureV2, TYPE_ID).orElseThrow();
 		assertThat(v2Aspect.getContent().eGet(targetAttribute)).isEqualTo("temperature");
+	}
+
+	/**
+	 * <b>Use case 3b - the derived artifact at a version bump:</b> next to the authored,
+	 * version-independent file content sits an artifact a compiler <em>derived</em> from one
+	 * package instance - compiled OCL is the real case, and it holds the
+	 * {@code EStructuralFeature} instances it resolved against. Such an entry names its
+	 * version through {@code emf.fingerprint} and must stay on it: a copy on the new
+	 * version's tree would navigate the old package's features (issue #81). The
+	 * version-independent mapping keeps spanning both versions, unchanged.
+	 */
+	@Test
+	public void testDerivedContentPinnedToItsVersionDoesNotFollowTheBump() throws Exception {
+		writeFixture("mappings.xmi", mapping("hum-1", "HumiditySensor", "humidity"));
+		String fingerprintV1 = whiteboard.registerPackage(sensorsPackage).orElseThrow().getModelFingerprint();
+		EObjectRegistryWriter writer = registryWithBridge();
+		writer.put("ocl-compiler", "temp-compiled", mapping("temp-compiled", "TemperatureSensor", "temperature"),
+				Map.of(FINGERPRINT_ATTRIBUTE, fingerprintV1));
+
+		EPackage sensorsV2 = EcoreUtil.copy(sensorsPackage);
+		EClass temperatureV2 = (EClass) sensorsV2.getEClassifier("TemperatureSensor");
+		EClass humidityV2 = (EClass) sensorsV2.getEClassifier("HumiditySensor");
+		attribute(temperatureV2, "accuracy");
+		whiteboard.registerPackage(sensorsV2);
+
+		assertThat(whiteboard.getClassAspect(humidityV2, TYPE_ID)).as("authored content spans versions").isPresent();
+		assertThat(whiteboard.getClassAspect(temperatureSensor, TYPE_ID)).as("the derived artifact keeps its version")
+				.isPresent();
+		assertThat(whiteboard.getClassAspect(temperatureV2, TYPE_ID)).as("and is not copied onto the new one")
+				.isEmpty();
+	}
+
+	/**
+	 * <b>Use case 3c - the derived artifact ahead of its model:</b> the compiler was run
+	 * against a version that is not deployed yet (a staged rollout, an atlas that already
+	 * knows the next model). The entry names that version, waits, and lands the moment it
+	 * registers - the handler replay of use case 2, narrowed to one version instead of all
+	 * of them.
+	 */
+	@Test
+	public void testDerivedContentWaitsForTheVersionItNames() throws Exception {
+		writeFixture("mappings.xmi", mapping("hum-1", "HumiditySensor", "humidity"));
+		EPackage sensorsV2 = EcoreUtil.copy(sensorsPackage);
+		EClass temperatureV2 = (EClass) sensorsV2.getEClassifier("TemperatureSensor");
+		attribute(temperatureV2, "accuracy");
+		String fingerprintV2 = FingerprintHelper.fingerprint(sensorsV2);
+		whiteboard.registerPackage(sensorsPackage);
+
+		EObjectRegistryWriter writer = registryWithBridge();
+		writer.put("ocl-compiler", "temp-compiled", mapping("temp-compiled", "TemperatureSensor", "temperature"),
+				Map.of(FINGERPRINT_ATTRIBUTE, fingerprintV2));
+		assertThat(whiteboard.getClassAspect(temperatureSensor, TYPE_ID)).as("v2 is not deployed yet").isEmpty();
+
+		whiteboard.registerPackage(sensorsV2);
+
+		assertThat(whiteboard.getClassAspect(temperatureV2, TYPE_ID)).as("lands on the version it names").isPresent();
+		assertThat(whiteboard.getClassAspect(temperatureSensor, TYPE_ID)).as("never on the other one").isEmpty();
 	}
 
 	/**

--- a/org.eclipse.fennec.emf.osgi.metadata/src/org/eclipse/fennec/emf/osgi/metadata/impl/MetadataServiceImpl.java
+++ b/org.eclipse.fennec.emf.osgi.metadata/src/org/eclipse/fennec/emf/osgi/metadata/impl/MetadataServiceImpl.java
@@ -274,7 +274,43 @@ public class MetadataServiceImpl implements MetadataWhiteboard {
 
 	@Override
 	public Optional<ClassMetadata> getClassMetadata(EClass eClass) {
-		return eClass != null ? Optional.ofNullable(classesByEClass.get(eClass)) : Optional.empty();
+		if (eClass == null) {
+			return Optional.empty();
+		}
+		ClassMetadata classMetadata = classesByEClass.get(eClass);
+		return classMetadata != null ? Optional.of(classMetadata) : sharedClassMetadata(eClass);
+	}
+
+	/**
+	 * Resolves an EClass whose instance was never indexed, through the model version it
+	 * belongs to.
+	 * <p>
+	 * Two Java instances can be one model version: a generated {@link EPackage} and the same
+	 * model loaded from its {@code .ecore} yield the same fingerprint by design - the
+	 * equivalence gate asserts it - and registration deduplicates them onto one tree. Only
+	 * the instance that built the tree lands in {@link #classesByEClass}, so a consumer
+	 * holding the other instance would find nothing although the tree describes its model
+	 * exactly. Instance identity is a cache key here, never the identity of the model.
+	 * <p>
+	 * The correspondence is exact rather than a guess: equal fingerprints mean equal
+	 * structure, and a classifier name is unique within its package. Deliberately
+	 * <b>not</b> memoized - a memo would have to be invalidated on withdrawal, and a stale
+	 * entry would answer with the metadata of a version that is no longer live.
+	 *
+	 * @param eClass the class to resolve; may be {@code null}
+	 * @return the metadata of the class in its model version's tree, or empty
+	 */
+	private Optional<ClassMetadata> sharedClassMetadata(EClass eClass) {
+		EPackage ePackage = eClass == null ? null : eClass.getEPackage();
+		if (ePackage == null) {
+			return Optional.empty();
+		}
+		PackageMetadata packageMetadata = packagesByFingerprint.get(memoizedFingerprint(ePackage));
+		if (packageMetadata == null) {
+			return Optional.empty();
+		}
+		return packageMetadata.getClasses().stream().filter(candidate -> Objects.equals(candidate.getName(),
+				eClass.getName())).findFirst();
 	}
 
 	@Override
@@ -289,7 +325,18 @@ public class MetadataServiceImpl implements MetadataWhiteboard {
 
 	@Override
 	public Optional<FeatureMetadata> getFeatureMetadata(EStructuralFeature feature) {
-		return feature != null ? Optional.ofNullable(featuresByEFeature.get(feature)) : Optional.empty();
+		if (feature == null) {
+			return Optional.empty();
+		}
+		FeatureMetadata featureMetadata = featuresByEFeature.get(feature);
+		if (featureMetadata != null) {
+			return Optional.of(featureMetadata);
+		}
+		// Same reasoning as sharedClassMetadata: by name, because feature names are unique
+		// within a class - and unlike operations, features may be skipped while the tree is
+		// built, so a position would not correspond.
+		return sharedClassMetadata(feature.getEContainingClass())
+				.flatMap(classMetadata -> getFeatureMetadataFromClass(feature.getName(), classMetadata));
 	}
 
 	@Override
@@ -313,7 +360,24 @@ public class MetadataServiceImpl implements MetadataWhiteboard {
 
 	@Override
 	public Optional<OperationMetadata> getOperationMetadata(EOperation operation) {
-		return operation != null ? Optional.ofNullable(operationsByEOperation.get(operation)) : Optional.empty();
+		if (operation == null) {
+			return Optional.empty();
+		}
+		OperationMetadata operationMetadata = operationsByEOperation.get(operation);
+		if (operationMetadata != null) {
+			return Optional.of(operationMetadata);
+		}
+		// By position, not by name: names are not unique under overloading. Operations are
+		// mirrored one for one, and equal fingerprints imply an equal declared order, so the
+		// index of the operation in its class is the exact correspondence.
+		EClass owner = operation.getEContainingClass();
+		if (owner == null) {
+			return Optional.empty();
+		}
+		int position = owner.getEOperations().indexOf(operation);
+		return sharedClassMetadata(owner).map(ClassMetadata::getOperations)
+				.filter(operations -> position >= 0 && position < operations.size())
+				.map(operations -> operations.get(position));
 	}
 
 	@Override

--- a/org.eclipse.fennec.emf.osgi.metadata/test/org/eclipse/fennec/emf/osgi/metadata/impl/SameNsUriMultiVersionAcceptanceTest.java
+++ b/org.eclipse.fennec.emf.osgi.metadata/test/org/eclipse/fennec/emf/osgi/metadata/impl/SameNsUriMultiVersionAcceptanceTest.java
@@ -20,13 +20,19 @@ import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EGenericType;
+import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EParameter;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.ETypeParameter;
 import org.eclipse.emf.ecore.EcoreFactory;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.fennec.emf.osgi.components.fingerprint.DefaultFingerprintService;
+import org.eclipse.fennec.emf.osgi.metadata.MetadataHandler;
+import org.eclipse.fennec.emf.osgi.model.metadata.AspectEntry;
+import org.eclipse.fennec.emf.osgi.model.metadata.ClassMetadata;
+import org.eclipse.fennec.emf.osgi.model.metadata.MetadataFactory;
 import org.eclipse.fennec.emf.osgi.model.metadata.PackageMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -351,6 +357,163 @@ class SameNsUriMultiVersionAcceptanceTest {
 				.get()
 				.extracting(PackageMetadata::getEPackage)
 				.isSameAs(stringBoxed);
+	}
+
+	// ---- representation independence: two instances, one model version --------------
+
+	/**
+	 * A generated {@code EPackage} and the same model loaded from its {@code .ecore} are two
+	 * Java instances of <b>one</b> model version - that is a guaranteed property, asserted by
+	 * the equivalence gate (issue #57) - and the dedupe above puts them on one tree. Element
+	 * lookups are keyed by instance for speed, but instance identity is a cache key, not the
+	 * identity of the model: an EClass of the second instance must resolve to the shared
+	 * metadata rather than to nothing.
+	 */
+	@Test
+	void testDedupedSecondInstanceResolvesTheSharedClassMetadata() {
+		EPackage generated = draftPackage();
+		EPackage loaded = draftPackage();
+		service.registerPackage(generated);
+		service.registerPackage(loaded);
+
+		assertThat(service.getClassMetadata(personOf(loaded)))
+				.as("the second instance's EClass must resolve to the one tree both share")
+				.containsSame(service.getClassMetadata(personOf(generated)).orElseThrow());
+	}
+
+	@Test
+	void testDedupedSecondInstanceResolvesTheSharedFeatureMetadata() {
+		EPackage generated = draftPackage();
+		EPackage loaded = draftPackage();
+		service.registerPackage(generated);
+		service.registerPackage(loaded);
+
+		assertThat(service.getFeatureMetadata(personOf(loaded).getEStructuralFeature("name")))
+				.containsSame(service.getFeatureMetadata(personOf(generated).getEStructuralFeature("name"))
+						.orElseThrow());
+	}
+
+	/**
+	 * Operation names are not unique under overloading, so the correspondence between the two
+	 * instances must be positional - which is sound exactly because equal fingerprints imply
+	 * an equal declared order.
+	 */
+	@Test
+	void testDedupedSecondInstanceResolvesOverloadedOperationsByPosition() {
+		EPackage generated = personPackageWithOverloads();
+		EPackage loaded = personPackageWithOverloads();
+		service.registerPackage(generated);
+		service.registerPackage(loaded);
+
+		List<EOperation> loadedOperations = personOf(loaded).getEOperations();
+		assertThat(loadedOperations).hasSize(2);
+		assertThat(service.getOperationMetadata(loadedOperations.get(0)).orElseThrow().getParameters()).isEmpty();
+		assertThat(service.getOperationMetadata(loadedOperations.get(1)).orElseThrow().getParameters()).hasSize(1);
+	}
+
+	/**
+	 * The case this exists for: content anchored on the model version - an
+	 * {@code AspectEntry} contributed when the first instance registered - must be answerable
+	 * through the second instance's EClass. Otherwise a consumer holding an EObject loaded
+	 * through a ResourceSet whose package registry carries the other instance finds nothing,
+	 * although the content sits on the very tree that describes its model.
+	 */
+	@Test
+	void testDedupedSecondInstanceFindsAspectsOfTheModelVersion() {
+		service.addMetadataHandler(new MetadataHandler() {
+
+			@Override
+			public void onPackageRegistered(PackageMetadata packageMetadata) {
+				AspectEntry aspect = MetadataFactory.eINSTANCE.createAspectEntry();
+				aspect.setTypeId("mapping");
+				packageMetadata.getClasses().get(0).getAspects().add(aspect);
+			}
+		});
+		service.registerPackage(draftPackage());
+		EPackage loaded = draftPackage();
+		service.registerPackage(loaded);
+
+		assertThat(service.getClassAspect(personOf(loaded), "mapping"))
+				.as("the aspect of the shared model version must answer for either instance")
+				.isPresent();
+	}
+
+	/** The pull path dedupes as well, so it must resolve elements just the same. */
+	@Test
+	void testPullCreatedVersionResolvesElementsOfAnEqualInstance() {
+		service.getPackageMetadata(draftPackage());
+		EPackage loaded = draftPackage();
+
+		assertThat(service.getClassMetadata(personOf(loaded))).isPresent();
+	}
+
+	/**
+	 * The fallback must not become a name lookup: two <em>diverging</em> instances are two
+	 * model versions and each EClass keeps resolving to its own.
+	 */
+	@Test
+	void testDivergingInstancesStillResolveTheirOwnClassMetadata() {
+		EPackage draft = draftPackage();
+		EPackage approved = approvedPackage();
+		service.registerPackage(draft);
+		service.registerPackage(approved);
+
+		ClassMetadata draftClass = service.getClassMetadata(personOf(draft)).orElseThrow();
+		ClassMetadata approvedClass = service.getClassMetadata(personOf(approved)).orElseThrow();
+		assertThat(draftClass).isNotSameAs(approvedClass);
+		assertThat(draftClass.getFeatures().get(0).getName()).isEqualTo("name");
+		assertThat(approvedClass.getFeatures().get(0).getName()).isEqualTo("fullName");
+	}
+
+	@Test
+	void testUnknownModelVersionResolvesToNothing() {
+		service.registerPackage(draftPackage());
+
+		assertThat(service.getClassMetadata(personOf(approvedPackage())))
+				.as("a version nobody registered has no metadata - the fallback is per version, not per name")
+				.isEmpty();
+	}
+
+	/**
+	 * No stale answers: once the last registration of a version is gone, neither instance
+	 * resolves any longer. A memoized fallback would leak metadata of a withdrawn tree here.
+	 */
+	@Test
+	void testWithdrawnVersionResolvesForNeitherInstance() {
+		EPackage generated = draftPackage();
+		EPackage loaded = draftPackage();
+		service.registerPackage(generated);
+		service.registerPackage(loaded);
+		assertThat(service.getClassMetadata(personOf(loaded))).isPresent();
+
+		service.unregisterPackage(generated);
+		service.unregisterPackage(loaded);
+
+		assertThat(service.getClassMetadata(personOf(loaded))).isEmpty();
+		assertThat(service.getClassMetadata(personOf(generated))).isEmpty();
+	}
+
+	private static EClass personOf(EPackage ePackage) {
+		return (EClass) ePackage.getEClassifier("Person");
+	}
+
+	/** {@code Person{name, greet(), greet(EString)}} - the overload case. */
+	private static EPackage personPackageWithOverloads() {
+		EPackage ePackage = personPackage("name");
+		EClass person = personOf(ePackage);
+
+		EOperation greet = EcoreFactory.eINSTANCE.createEOperation();
+		greet.setName("greet");
+		person.getEOperations().add(greet);
+
+		EOperation greetSomeone = EcoreFactory.eINSTANCE.createEOperation();
+		greetSomeone.setName("greet");
+		EParameter who = EcoreFactory.eINSTANCE.createEParameter();
+		who.setName("who");
+		who.setEType(EcorePackage.Literals.ESTRING);
+		greetSomeone.getEParameters().add(who);
+		person.getEOperations().add(greetSomeone);
+		return ePackage;
 	}
 
 	private static String firstFeatureName(PackageMetadata metadata) {


### PR DESCRIPTION
Closes #81.

## The bug

`RegistryMetadataBridge` placed an entry's aspect on **every** live version tree of its anchor's nsURI. `place` snapshots the content with `EcoreUtil.copy`, which copies containment and leaves non-containment references pointing at the **originals** — so a derived artifact (compiled OCL holding the `EStructuralFeature`/`EClassifier` instances it resolved against) sat on a foreign version's tree while navigating the package it was built from. With dynamic EMF that fails at `eGet`; with generated code it may resolve by name and quietly answer from the wrong model version.

Placement now honours the entry's `emf.fingerprint`: content that names no version stays version-independent and spans every live version (mappings, profiles — a version bump still costs nothing), content that names one goes onto that version and no other. Placement is therefore also provenance — the `modelFingerprint` of the `PackageMetadata` holding an aspect *is* the fingerprint of the package the content was built from, with no second bookkeeping to keep in sync.

## Also in here

**A blank or malformed fingerprint must not drop content.** `EPackage#fingerprint()` requires an absent value to be read as unknown, *never* as a mismatch — the property is optional precisely because a provider may not be able to state it. Blank and whitespace values are therefore version-independent, single-element arrays/collections are unwrapped (the shape a value takes when properties are copied from service properties or Configurator JSON), and a genuinely multi-valued one names no version.

**The unplaced-content warning triggers on no placement**, not on no version match, which also covers a named version that dropped the anchor class. A cold start with no live version stays silent — that is the normal state, not a suspicion.

**`onPackageUnregistered` forgot nothing.** It compared `EcoreUtil.getRootContainer(aspect) == packageMetadata`, but `MetadataRegistry.packages` is containment and `withdraw` calls handlers *before* removing the version, so the root container is always the registry. Now `EcoreUtil.isAncestor`.

**One model version can arrive as several `EPackage` instances** (`org.eclipse.fennec.emf.osgi.metadata`). A generated package and the same model loaded from its `.ecore` yield the same fingerprint by design — `FingerprintEquivalenceGateTest` (#57) guarantees it — and registration deduplicates them onto one tree. Only the instance that built the tree was indexed, so a consumer holding the other one found no `ClassMetadata` and no aspects at all. Element lookups now fall back through the model version: classes and features by name, operations by declared position, which equal fingerprints make exact. Deliberately not memoized, so a withdrawn version cannot answer.

## Tests

Written test-first; 35 new tests, 4 + 6 of them red against the unfixed code.

- `FingerprintScopedPlacementTest` (new, 19) — pinning across 1, 0, 3 and 5 live versions of one nsURI in both registration orders; pin-state transitions (unpinned → pinned shrinks to one tree and back); anchor missing in the named version; multi-anchor pinning; blank/array/multi-valued properties; legacy model without an advertised fingerprint; withdrawn-version bookkeeping. Log behaviour is asserted through a handler on the bridge logger, so "silent vs. loud" is part of the contract.
- `DerivedContentReferenceIntegrityTest` (new, 6) — the reason for the guard, at reference level: the copy keeps its non-containment references on the package instance it was derived from, redirects intra-content references to the copy, and preserves references out of nested containment. One test pins the documented **limit** — unpinned content spans versions and keeps its origin references — so the MUST rule cannot be mistaken for something the guard already handles.
- `InitialProviderBridgeUseCasesTest` — use cases 3b (derived artifact at a version bump, next to version-independent file content) and 3c (derived artifact ahead of its model).
- `EObjectRegistryIntegrationTest` — end-to-end in Felix against the fingerprints the running framework computes. Verified to fail without the fix.
- `SameNsUriMultiVersionAcceptanceTest` (9 new) — the two-instances-one-version case, including that a withdrawn version resolves for neither instance and that diverging instances keep resolving to their own.

`./gradlew build` and `testOSGi` green.

## Docs

`docs/eobject-registry-guide.md` gains a teachable section: mermaid diagrams for the placement routing, the reference hazard and the pending/replay ordering; a worked producer component with the two conventions that matter (the key carries the version, the fingerprint comes from the model); the two failure shapes per model style; and a table of what happens when content reaches no tree. Plus the warning against deriving inside `onPackageRegistered` and pushing from there — the new tree is published after all handlers ran, so placement would depend on wiring order.

`docs/metadata-service-guide.md` documents the counterpart with its own diagram.

Mermaid needs a plugin to render on the VitePress site (GitHub renders the fences natively), so `vitepress-plugin-mermaid` + `mermaid` are added as devDependencies and the config is wrapped in `withMermaid`. `npm run docs:build` passes and all four diagrams render as diagrams, not code blocks; the sources were parse-checked against mermaid itself.

## Not in here

No package version increments — nothing is released yet. Signatures are unchanged, and no new `Import-Package` appears: `FINGERPRINT_ATTRIBUTE` is a compile-time constant, so the bridge's manifest is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
